### PR TITLE
Drop the trailing slash from jenkins url.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -35,7 +35,7 @@ distributions:
       default: bouncy/release-build.yaml
       ubv8: bouncy/release-bionic-arm64-build.yaml
     source_builds: {}
-jenkins_url: http://build.ros2.org/
+jenkins_url: http://build.ros2.org
 notification_emails:
   - steven+build.ros2.org@openrobotics.org
 prerequisites:


### PR DESCRIPTION
We're standardizing on no trailing slash to match build.ros.org configuration.

If you see errors after this merge, check first that your ~/.buildfarm/jenkins.ini has an entry for `build.ros2.org` rather than `build.ros2.org/`.
There is still a lingering issue because of a lack of configurable timeout handling in the jenkinsapi stack and Jenkins will sometimes not respond quickly enough to the first attempt to iterate all jobs.

Follow up to https://github.com/ros2/ci/pull/168