### PR TITLE
Add RTI_NC_LICENSE_ACCEPTED environment variable to buildfarm builds.

### DIFF
--- a/bouncy/release-build.yaml
+++ b/bouncy/release-build.yaml
@@ -2,6 +2,10 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
+
+build_environment_variables:
+  RTI_NC_LICENSE_ACCEPTED: 'yes'
+
 jenkins_binary_job_priority: 82
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 78

--- a/bouncy/source-build.yaml
+++ b/bouncy/source-build.yaml
@@ -1,6 +1,9 @@
 %YAML 1.1
 # ROS buildfarm source-build file
 ---
+build_environment_variables:
+  RTI_NC_LICENSE_ACCEPTED: 'yes'
+
 jenkins_commit_job_priority: 58
 jenkins_job_timeout: 120
 jenkins_pull_request_job_priority: 48


### PR DESCRIPTION
This config value relies on features in https://github.com/ros-infrastructure/ros_buildfarm/pull/554 for functionality but I do not think anything will break if it's added before that merges.

This value is only needed on amd64 as there is no RTI package for arm64. The 'yes' is quoted to avoid it being interpreted by pyyaml as a boolean which would cause it to manifest as `True` rather than `yes` in the generated Dockerfile.