### PR TITLE
[bouncy] enable email notifications for binary jobs

### DIFF
--- a/bouncy/release-bionic-arm64-build.yaml
+++ b/bouncy/release-bionic-arm64-build.yaml
@@ -11,7 +11,7 @@ notifications:
   emails:
   - mikael+build.ros2.org@openrobotics.org
   - ros2-buildfarm-bouncy@googlegroups.com
-  maintainers: false
+  maintainers: true
 sync:
   package_count: 1
 repositories:

--- a/bouncy/release-build.yaml
+++ b/bouncy/release-build.yaml
@@ -14,7 +14,7 @@ notifications:
   emails:
   - mikael+build.ros2.org@openrobotics.org
   - ros2-buildfarm-bouncy@googlegroups.com
-  maintainers: false
+  maintainers: true
 sync:
   package_count: 1
 repositories:


### PR DESCRIPTION
Now that maintainers have been updated for most packages we can enable these notifications.
We should also rachet up the package count now that more packages are out but this will be done in a follow-up PR