### PR TITLE
Set build tool per distro

### DIFF
--- a/bouncy/source-build.yaml
+++ b/bouncy/source-build.yaml
@@ -3,7 +3,7 @@
 ---
 build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
-
+build_tool: colcon
 jenkins_commit_job_priority: 58
 jenkins_job_timeout: 120
 jenkins_pull_request_job_priority: 48

--- a/index.yaml
+++ b/index.yaml
@@ -106,7 +106,7 @@ prerequisites:
     qYE=
     =Vgio
     -----END PGP PUBLIC KEY BLOCK-----
-rosdistro_index_url: https://raw.githubusercontent.com/ros2/rosdistro/ros2/index.yaml
+rosdistro_index_url: https://raw.githubusercontent.com/ros2/rosdistro/ros2/index-v4.yaml
 status_page_repositories:
   default:
     - http://repo.ros2.org/ubuntu/building


### PR DESCRIPTION
This is in preparation of ros-infrastructure/ros_buildfarm#585.

The `ros_version` is necessary to decide about the installation of the `catkin` or `ros-workspace` package without the need to hardcode ROS distro names in the `ros_buildfarm` code.

The `build_tool` option is used to choose `colcon` over the default (which is `catkin_make_isolated`). The option is independent from the ROS version since it should be possible to build ROS 1 distributions with `colcon`.