### PR TITLE
blacklist ros_workspace repo

### DIFF
--- a/dashing/source-build.yaml
+++ b/dashing/source-build.yaml
@@ -81,6 +81,8 @@ repositories:
   urls:
   - http://repo.ros2.org/ubuntu/testing
   - http://repositories.ros.org/ubuntu/main
+repository_blacklist:
+- ros_workspace
 targets:
   ubuntu:
     bionic:


### PR DESCRIPTION
Since this job can conceptionally not work since it relies on higher level packages to be available.