### PR TITLE
Increase package sync threshold for Dashing.

### DIFF
--- a/dashing/release-bionic-arm64-build.yaml
+++ b/dashing/release-bionic-arm64-build.yaml
@@ -13,7 +13,7 @@ notifications:
   - ros2-buildfarm-dashing@googlegroups.com
   maintainers: true
 sync:
-  package_count: 3
+  package_count: 180
 repositories:
   keys:
   - |

--- a/dashing/release-build.yaml
+++ b/dashing/release-build.yaml
@@ -16,7 +16,7 @@ notifications:
   - ros2-buildfarm-dashing@googlegroups.com
   maintainers: true
 sync:
-  package_count: 3
+  package_count: 180
 repositories:
   keys:
   - |


### PR DESCRIPTION
There are currently 196 total packages.