### PR TITLE
set ROS_PYTHON_VERSION env var for Dashing devel builds

### DIFF
--- a/dashing/source-build.yaml
+++ b/dashing/source-build.yaml
@@ -2,6 +2,7 @@
 # ROS buildfarm source-build file
 ---
 build_environment_variables:
+  ROS_PYTHON_VERSION: 3
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 jenkins_commit_job_priority: 56


### PR DESCRIPTION
Related to ros-infrastructure/ros_buildfarm#634.