### PR TITLE
Assume non-ROS packages are present in CI overlay jobs

### DIFF
--- a/eloquent/ci-overlay.yaml
+++ b/eloquent/ci-overlay.yaml
@@ -92,6 +92,10 @@ repositories:
   urls:
   - http://repo.ros2.org/ubuntu/testing
   - http://repositories.ros.org/ubuntu/main
+skip_rosdep_keys:
+- fastcdr
+- fastrtps
+- urdfdom_headers
 targets:
   ubuntu:
     bionic:


### PR DESCRIPTION
This is a temporary workaround until we can create a more robust way to detect the non-ROS packages that are present in the underlay. These are the only non-ROS packages I could find in the current `ros2.repos` file, so I believe that this list should be complete.

Right now, `catkin_pkg` and `colcon` are both used to crawl the workspaces for packages. `catkin_pkg` gives us a list of ROS packages and their dependencies (for recursive enumeration), and `colcon` gives us a list of all package names, including non-ROS packages.

This works correctly for the target (overlay) workspace, but the non-ROS packages that were detected during the underlay build are no longer detected in the underlay install space without their source files present. If an overlay package recursively depends on any of those non-ROS packages, a rosdep resolution error occurs when the package isn't found in any workspaces and is assumed to be an external dependency.

Improving the enumeration method for underlay packages such that non-ROS packages are found (such as using the `colcon` index) would eliminate the need for this workaround.

This whole problem is very analogous to why we specify `--skip-keys` to rosdep in the ROS 2 source installation instructions: https://index.ros.org/doc/ros2/Installation/Dashing/Linux-Development-Setup/#install-dependencies-using-rosdep