### PR TITLE
Tie CI jobs to dedicated agents

### DIFF
--- a/crystal/ci-nightly.yaml
+++ b/crystal/ci-nightly.yaml
@@ -20,6 +20,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 240

--- a/crystal/ci-overlay.yaml
+++ b/crystal/ci-overlay.yaml
@@ -20,6 +20,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 240
 repos_files:

--- a/dashing/ci-nightly-connext.yaml
+++ b/dashing/ci-nightly-connext.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/dashing/ci-nightly-debug.yaml
+++ b/dashing/ci-nightly-debug.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/dashing/ci-nightly-extra-rmw-release.yaml
+++ b/dashing/ci-nightly-extra-rmw-release.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/dashing/ci-nightly-fastrtps-dynamic.yaml
+++ b/dashing/ci-nightly-fastrtps-dynamic.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/dashing/ci-nightly-fastrtps.yaml
+++ b/dashing/ci-nightly-fastrtps.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/dashing/ci-nightly-opensplice.yaml
+++ b/dashing/ci-nightly-opensplice.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/dashing/ci-nightly-release.yaml
+++ b/dashing/ci-nightly-release.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/dashing/ci-overlay.yaml
+++ b/dashing/ci-overlay.yaml
@@ -21,6 +21,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 240
 repos_files:

--- a/eloquent/ci-nightly-connext.yaml
+++ b/eloquent/ci-nightly-connext.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/eloquent/ci-nightly-debug.yaml
+++ b/eloquent/ci-nightly-debug.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/eloquent/ci-nightly-extra-rmw-release.yaml
+++ b/eloquent/ci-nightly-extra-rmw-release.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/eloquent/ci-nightly-fastrtps-dynamic.yaml
+++ b/eloquent/ci-nightly-fastrtps-dynamic.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/eloquent/ci-nightly-fastrtps.yaml
+++ b/eloquent/ci-nightly-fastrtps.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/eloquent/ci-nightly-opensplice.yaml
+++ b/eloquent/ci-nightly-opensplice.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/eloquent/ci-nightly-release.yaml
+++ b/eloquent/ci-nightly-release.yaml
@@ -22,6 +22,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300

--- a/eloquent/ci-overlay.yaml
+++ b/eloquent/ci-overlay.yaml
@@ -21,6 +21,7 @@ install_packages:
 - ros-melodic-rosmsg
 - ros-melodic-rospy-tutorials
 - ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 240
 repos_files:


### PR DESCRIPTION
In an effort to narrow down the source of the CI build performance shortcomings, @nuclearsandwich and I would like to try some builds on dedicated agents.