### PR TITLE
Ignore FOONATHAN_MEMORY rosdep key

### DIFF
--- a/eloquent/ci-nightly-connext.yaml
+++ b/eloquent/ci-nightly-connext.yaml
@@ -96,6 +96,8 @@ repositories:
   urls:
   - http://repo.ros2.org/ubuntu/testing
   - http://repositories.ros.org/ubuntu/main
+skip_rosdep_keys:
+- FOONATHAN_MEMORY
 targets:
   ubuntu:
     bionic:

--- a/eloquent/ci-nightly-debug.yaml
+++ b/eloquent/ci-nightly-debug.yaml
@@ -96,6 +96,8 @@ repositories:
   urls:
   - http://repo.ros2.org/ubuntu/testing
   - http://repositories.ros.org/ubuntu/main
+skip_rosdep_keys:
+- FOONATHAN_MEMORY
 targets:
   ubuntu:
     bionic:

--- a/eloquent/ci-nightly-extra-rmw-release.yaml
+++ b/eloquent/ci-nightly-extra-rmw-release.yaml
@@ -95,6 +95,8 @@ repositories:
   urls:
   - http://repo.ros2.org/ubuntu/testing
   - http://repositories.ros.org/ubuntu/main
+skip_rosdep_keys:
+- FOONATHAN_MEMORY
 targets:
   ubuntu:
     bionic:

--- a/eloquent/ci-nightly-fastrtps-dynamic.yaml
+++ b/eloquent/ci-nightly-fastrtps-dynamic.yaml
@@ -96,6 +96,8 @@ repositories:
   urls:
   - http://repo.ros2.org/ubuntu/testing
   - http://repositories.ros.org/ubuntu/main
+skip_rosdep_keys:
+- FOONATHAN_MEMORY
 targets:
   ubuntu:
     bionic:

--- a/eloquent/ci-nightly-fastrtps.yaml
+++ b/eloquent/ci-nightly-fastrtps.yaml
@@ -96,6 +96,8 @@ repositories:
   urls:
   - http://repo.ros2.org/ubuntu/testing
   - http://repositories.ros.org/ubuntu/main
+skip_rosdep_keys:
+- FOONATHAN_MEMORY
 targets:
   ubuntu:
     bionic:

--- a/eloquent/ci-nightly-opensplice.yaml
+++ b/eloquent/ci-nightly-opensplice.yaml
@@ -96,6 +96,8 @@ repositories:
   urls:
   - http://repo.ros2.org/ubuntu/testing
   - http://repositories.ros.org/ubuntu/main
+skip_rosdep_keys:
+- FOONATHAN_MEMORY
 targets:
   ubuntu:
     bionic:

--- a/eloquent/ci-nightly-release.yaml
+++ b/eloquent/ci-nightly-release.yaml
@@ -96,6 +96,8 @@ repositories:
   urls:
   - http://repo.ros2.org/ubuntu/testing
   - http://repositories.ros.org/ubuntu/main
+skip_rosdep_keys:
+- FOONATHAN_MEMORY
 targets:
   ubuntu:
     bionic:

--- a/eloquent/ci-overlay.yaml
+++ b/eloquent/ci-overlay.yaml
@@ -93,6 +93,8 @@ repositories:
   urls:
   - http://repo.ros2.org/ubuntu/testing
   - http://repositories.ros.org/ubuntu/main
+skip_rosdep_keys:
+- FOONATHAN_MEMORY
 targets:
   ubuntu:
     bionic:


### PR DESCRIPTION
This should get the Eloquent CI nightlies out of the red on build.ros2.org.

Related to ros2/ros2#756
Immediate workaround for eProsima/foonathan_memory_vendor#9

ros2/ros2cli#310 is also required to get the jobs building.

Test job: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Eci__nightly-release_ubuntu_bionic_amd64&build=49)](http://build.ros2.org/view/Eci/job/Eci__nightly-release_ubuntu_bionic_amd64/49/)