### PR TITLE
Add navigation2 jobs

### DIFF
--- a/eloquent/ci-nightly-navigation2-prerequisites.yaml
+++ b/eloquent/ci-nightly-navigation2-prerequisites.yaml
@@ -4,11 +4,9 @@
 build_environment_variables:
   CMAKE_PREFIX_PATH: '/opt/ros/melodic:$CMAKE_PREFIX_PATH'
   LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
-  NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
   PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
   ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
   ROS_PYTHON_VERSION: '3'
-  RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 install_packages:

--- a/eloquent/ci-nightly-navigation2-prerequisites.yaml
+++ b/eloquent/ci-nightly-navigation2-prerequisites.yaml
@@ -1,82 +1,38 @@
 %YAML 1.1
-# ROS buildfarm index file
+# ROS buildfarm ci-build file
 ---
-distributions:
-  bouncy:
-    ci_builds: {}
-    doc_builds: {}
-    notification_emails:
-      - mikael+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-bouncy@googlegroups.com
-    release_builds:
-      default: bouncy/release-build.yaml
-      ubv8: bouncy/release-bionic-arm64-build.yaml
-    source_builds:
-      default: bouncy/source-build.yaml
-  crystal:
-    ci_builds:
-      nightly: crystal/ci-nightly.yaml
-      overlay: crystal/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-crystal@googlegroups.com
-    release_builds:
-      default: crystal/release-build.yaml
-      ubv8: crystal/release-bionic-arm64-build.yaml
-    source_builds:
-      default: crystal/source-build.yaml
-  dashing:
-    ci_builds:
-      nightly-connext: dashing/ci-nightly-connext.yaml
-      nightly-debug: dashing/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: dashing/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: dashing/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: dashing/ci-nightly-fastrtps-dynamic.yaml
-      nightly-opensplice: dashing/ci-nightly-opensplice.yaml
-      nightly-release: dashing/ci-nightly-release.yaml
-      overlay: dashing/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-dashing@googlegroups.com
-    release_builds:
-      default: dashing/release-build.yaml
-      ubv8: dashing/release-bionic-arm64-build.yaml
-    source_builds:
-      default: dashing/source-build.yaml
-  eloquent:
-    ci_builds:
-      nightly-connext: eloquent/ci-nightly-connext.yaml
-      nightly-debug: eloquent/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: eloquent/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: eloquent/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: eloquent/ci-nightly-fastrtps-dynamic.yaml
-      nightly-navigation2: eloquent/ci-nightly-navigation2.yaml
-      nightly-navigation2-prerequisites: eloquent/ci-nightly-navigation2-prerequisites.yaml
-      nightly-opensplice: eloquent/ci-nightly-opensplice.yaml
-      nightly-release: eloquent/ci-nightly-release.yaml
-      overlay: eloquent/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - michael+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-eloquent@googlegroups.com
-    release_builds:
-      default: eloquent/release-build.yaml
-      ubv8: eloquent/release-bionic-arm64-build.yaml
-    source_builds:
-      default: eloquent/source-build.yaml
-jenkins_url: http://build.ros2.org
-notification_emails:
-  - steven+build.ros2.org@openrobotics.org
-prerequisites:
-  debian_repositories:
-  - http://repo.ros2.org/ubuntu/building
-  - http://repositories.ros.org/ubuntu/main
-  debian_repository_keys:
+build_environment_variables:
+  CMAKE_PREFIX_PATH: '/opt/ros/melodic:$CMAKE_PREFIX_PATH'
+  LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
+  NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
+  PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
+  ROS_PYTHON_VERSION: '3'
+  RTI_NC_LICENSE_ACCEPTED: 'yes'
+build_tool: colcon
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+install_packages:
+- libasio-dev # for FastRTPS
+- libtinyxml2-dev # for FastRTPS
+- ros-melodic-common-msgs
+- ros-melodic-rosbash
+- ros-melodic-roscpp
+- ros-melodic-roscpp-tutorials
+- ros-melodic-roslaunch
+- ros-melodic-rosmsg
+- ros-melodic-rospy-tutorials
+- ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
+jenkins_job_priority: 50
+jenkins_job_timeout: 240
+jenkins_job_upstream_triggers:
+- nightly-release
+repos_files:
+- https://github.com/ros2/ros2/raw/navigation2/navigation2-prerequisites.repos
+repositories:
+  keys:
   - |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
-    Version: GnuPGv1
+    Version: GnuPG v1
 
     mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
     VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
@@ -136,11 +92,14 @@ prerequisites:
     qYE=
     =Vgio
     -----END PGP PUBLIC KEY BLOCK-----
-rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
-status_page_repositories:
-  default:
-    - http://repo.ros2.org/ubuntu/building
-    - http://repo.ros2.org/ubuntu/testing
-    - http://repo.ros2.org/ubuntu/main
-type: buildfarm
+  urls:
+  - http://repo.ros2.org/ubuntu/testing
+  - http://repositories.ros.org/ubuntu/main
+targets:
+  ubuntu:
+    bionic:
+      amd64:
+type: ci-build
+underlay_from_ci_jobs:
+- nightly-release
 version: 1

--- a/eloquent/ci-nightly-navigation2-prerequisites.yaml
+++ b/eloquent/ci-nightly-navigation2-prerequisites.yaml
@@ -6,10 +6,11 @@ build_environment_variables:
   LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
   NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
   PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
+  ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+build_tool_args: '--cmake-args --no-warn-unused-cli'
 install_packages:
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS
@@ -25,7 +26,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 240
 jenkins_job_upstream_triggers:
-- nightly-release
+- nightly-fastrtps
 repos_files:
 - https://github.com/ros2/ros2/raw/navigation2/navigation2-prerequisites.repos
 repositories:
@@ -101,5 +102,5 @@ targets:
       amd64:
 type: ci-build
 underlay_from_ci_jobs:
-- nightly-release
+- nightly-fastrtps
 version: 1

--- a/eloquent/ci-nightly-navigation2-prerequisites.yaml
+++ b/eloquent/ci-nightly-navigation2-prerequisites.yaml
@@ -26,7 +26,7 @@ jenkins_job_timeout: 240
 jenkins_job_upstream_triggers:
 - nightly-fastrtps
 repos_files:
-- https://github.com/ros2/ros2/raw/navigation2/navigation2-prerequisites.repos
+- https://github.com/ros-planning/navigation2/raw/master/tools/ros2_dependencies.repos
 repositories:
   keys:
   - |

--- a/eloquent/ci-nightly-navigation2.yaml
+++ b/eloquent/ci-nightly-navigation2.yaml
@@ -4,11 +4,9 @@
 build_environment_variables:
   CMAKE_PREFIX_PATH: '/opt/ros/melodic:$CMAKE_PREFIX_PATH'
   LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
-  NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
   PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
   ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
   ROS_PYTHON_VERSION: '3'
-  RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 install_packages:

--- a/eloquent/ci-nightly-navigation2.yaml
+++ b/eloquent/ci-nightly-navigation2.yaml
@@ -6,10 +6,11 @@ build_environment_variables:
   LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
   NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
   PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
+  ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+build_tool_args: '--cmake-args --no-warn-unused-cli'
 install_packages:
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS
@@ -101,6 +102,6 @@ targets:
       amd64:
 type: ci-build
 underlay_from_ci_jobs:
-- nightly-release
+- nightly-fastrtps
 - nightly-navigation2-prerequisites
 version: 1

--- a/eloquent/ci-nightly-navigation2.yaml
+++ b/eloquent/ci-nightly-navigation2.yaml
@@ -1,82 +1,38 @@
 %YAML 1.1
-# ROS buildfarm index file
+# ROS buildfarm ci-build file
 ---
-distributions:
-  bouncy:
-    ci_builds: {}
-    doc_builds: {}
-    notification_emails:
-      - mikael+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-bouncy@googlegroups.com
-    release_builds:
-      default: bouncy/release-build.yaml
-      ubv8: bouncy/release-bionic-arm64-build.yaml
-    source_builds:
-      default: bouncy/source-build.yaml
-  crystal:
-    ci_builds:
-      nightly: crystal/ci-nightly.yaml
-      overlay: crystal/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-crystal@googlegroups.com
-    release_builds:
-      default: crystal/release-build.yaml
-      ubv8: crystal/release-bionic-arm64-build.yaml
-    source_builds:
-      default: crystal/source-build.yaml
-  dashing:
-    ci_builds:
-      nightly-connext: dashing/ci-nightly-connext.yaml
-      nightly-debug: dashing/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: dashing/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: dashing/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: dashing/ci-nightly-fastrtps-dynamic.yaml
-      nightly-opensplice: dashing/ci-nightly-opensplice.yaml
-      nightly-release: dashing/ci-nightly-release.yaml
-      overlay: dashing/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-dashing@googlegroups.com
-    release_builds:
-      default: dashing/release-build.yaml
-      ubv8: dashing/release-bionic-arm64-build.yaml
-    source_builds:
-      default: dashing/source-build.yaml
-  eloquent:
-    ci_builds:
-      nightly-connext: eloquent/ci-nightly-connext.yaml
-      nightly-debug: eloquent/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: eloquent/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: eloquent/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: eloquent/ci-nightly-fastrtps-dynamic.yaml
-      nightly-navigation2: eloquent/ci-nightly-navigation2.yaml
-      nightly-navigation2-prerequisites: eloquent/ci-nightly-navigation2-prerequisites.yaml
-      nightly-opensplice: eloquent/ci-nightly-opensplice.yaml
-      nightly-release: eloquent/ci-nightly-release.yaml
-      overlay: eloquent/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - michael+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-eloquent@googlegroups.com
-    release_builds:
-      default: eloquent/release-build.yaml
-      ubv8: eloquent/release-bionic-arm64-build.yaml
-    source_builds:
-      default: eloquent/source-build.yaml
-jenkins_url: http://build.ros2.org
-notification_emails:
-  - steven+build.ros2.org@openrobotics.org
-prerequisites:
-  debian_repositories:
-  - http://repo.ros2.org/ubuntu/building
-  - http://repositories.ros.org/ubuntu/main
-  debian_repository_keys:
+build_environment_variables:
+  CMAKE_PREFIX_PATH: '/opt/ros/melodic:$CMAKE_PREFIX_PATH'
+  LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
+  NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
+  PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
+  ROS_PYTHON_VERSION: '3'
+  RTI_NC_LICENSE_ACCEPTED: 'yes'
+build_tool: colcon
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+install_packages:
+- libasio-dev # for FastRTPS
+- libtinyxml2-dev # for FastRTPS
+- ros-melodic-common-msgs
+- ros-melodic-rosbash
+- ros-melodic-roscpp
+- ros-melodic-roscpp-tutorials
+- ros-melodic-roslaunch
+- ros-melodic-rosmsg
+- ros-melodic-rospy-tutorials
+- ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
+jenkins_job_priority: 50
+jenkins_job_timeout: 240
+jenkins_job_upstream_triggers:
+- nightly-navigation2-prerequisites
+repos_files:
+- https://github.com/ros2/ros2/raw/navigation2/navigation2.repos
+repositories:
+  keys:
   - |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
-    Version: GnuPGv1
+    Version: GnuPG v1
 
     mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
     VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
@@ -136,11 +92,15 @@ prerequisites:
     qYE=
     =Vgio
     -----END PGP PUBLIC KEY BLOCK-----
-rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
-status_page_repositories:
-  default:
-    - http://repo.ros2.org/ubuntu/building
-    - http://repo.ros2.org/ubuntu/testing
-    - http://repo.ros2.org/ubuntu/main
-type: buildfarm
+  urls:
+  - http://repo.ros2.org/ubuntu/testing
+  - http://repositories.ros.org/ubuntu/main
+targets:
+  ubuntu:
+    bionic:
+      amd64:
+type: ci-build
+underlay_from_ci_jobs:
+- nightly-release
+- nightly-navigation2-prerequisites
 version: 1


### PR DESCRIPTION
Depends on ros-infrastructure/ros_buildfarm#670

I left the environment variables and default package set the same as the upstream CI jobs. I'm not sure they actually need to be the same, but this way we get a Dockerfile cache hit.