### PR TITLE
Add experimental armhf builds for Dashing

### DIFF
--- a/dashing/release-bionic-armhf-build.yaml
+++ b/dashing/release-bionic-armhf-build.yaml
@@ -1,83 +1,24 @@
 %YAML 1.1
-# ROS buildfarm index file
+# ROS buildfarm release-build file
 ---
-distributions:
-  bouncy:
-    ci_builds: {}
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-bouncy@googlegroups.com
-    release_builds:
-      default: bouncy/release-build.yaml
-      ubv8: bouncy/release-bionic-arm64-build.yaml
-    source_builds:
-      default: bouncy/source-build.yaml
-  crystal:
-    ci_builds:
-      nightly: crystal/ci-nightly.yaml
-      overlay: crystal/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-crystal@googlegroups.com
-    release_builds:
-      default: crystal/release-build.yaml
-      ubv8: crystal/release-bionic-arm64-build.yaml
-    source_builds:
-      default: crystal/source-build.yaml
-  dashing:
-    ci_builds:
-      nightly-connext: dashing/ci-nightly-connext.yaml
-      nightly-cyclonedds: dashing/ci-nightly-cyclonedds.yaml
-      nightly-debug: dashing/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: dashing/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: dashing/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: dashing/ci-nightly-fastrtps-dynamic.yaml
-      nightly-opensplice: dashing/ci-nightly-opensplice.yaml
-      nightly-release: dashing/ci-nightly-release.yaml
-      overlay: dashing/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-dashing@googlegroups.com
-    release_builds:
-      default: dashing/release-build.yaml
-      ubv8: dashing/release-bionic-arm64-build.yaml
-      ubhf: dashing/release-bionic-armhf-build.yaml
-    source_builds:
-      default: dashing/source-build.yaml
-  eloquent:
-    ci_builds:
-      nightly-connext: eloquent/ci-nightly-connext.yaml
-      nightly-cyclonedds: eloquent/ci-nightly-cyclonedds.yaml
-      nightly-debug: eloquent/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: eloquent/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: eloquent/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: eloquent/ci-nightly-fastrtps-dynamic.yaml
-      nightly-opensplice: eloquent/ci-nightly-opensplice.yaml
-      nightly-release: eloquent/ci-nightly-release.yaml
-      overlay: eloquent/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - michael+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-eloquent@googlegroups.com
-    release_builds:
-      default: eloquent/release-build.yaml
-      ubv8: eloquent/release-bionic-arm64-build.yaml
-    source_builds:
-      default: eloquent/source-build.yaml
-jenkins_url: http://build.ros2.org
-notification_emails:
+abi_incompatibility_assumed: true
+jenkins_binary_job_label: buildagent_armhf || dashing_binarydeb_ubhf
+jenkins_binary_job_priority: 80
+jenkins_binary_job_timeout: 720
+jenkins_source_job_priority: 76
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
   - steven+build.ros2.org@openrobotics.org
-prerequisites:
-  debian_repositories:
-  - http://repo.ros2.org/ubuntu/building
-  - http://repositories.ros.org/ubuntu/main
-  debian_repository_keys:
+  - ros2-buildfarm-dashing@googlegroups.com
+  maintainers: true
+sync:
+  package_count: 330
+repositories:
+  keys:
   - |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
-    Version: GnuPGv1
+    Version: GnuPG v1
 
     mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
     VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
@@ -137,11 +78,14 @@ prerequisites:
     qYE=
     =Vgio
     -----END PGP PUBLIC KEY BLOCK-----
-rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
-status_page_repositories:
-  default:
-    - http://repo.ros2.org/ubuntu/building
-    - http://repo.ros2.org/ubuntu/testing
-    - http://repo.ros2.org/ubuntu/main
-type: buildfarm
-version: 1
+  urls:
+  - http://repo.ros2.org/ubuntu/building
+  - http://repositories.ros.org/ubuntu/main
+target_repository: http://repo.ros2.org/ubuntu/building
+targets:
+  ubuntu:
+    bionic:
+      armhf:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/dashing/release-bionic-armhf-build.yaml
+++ b/dashing/release-bionic-armhf-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_label: buildagent_armhf || dashing_binarydeb_ubhf
-jenkins_binary_job_priority: 80
+jenkins_binary_job_priority: 99
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 76
 jenkins_source_job_timeout: 30


### PR DESCRIPTION
These builds cannot be enabled until the ROS 2 repos are updated to include the armhf architecture and the ROS 2 buildfarm has new armhf-compatible build agents added to it.

For ROS 2, our arm64 and amd64 builds were on separate hosts and so could share priority levels without conflicting. Since we can share hosts between armhf and arm64 I needed to pick a different priority level. Rather than shuffling everything I opted to make these debs the lowest priority available since they're not going to be officially supported for Dashing.