### PR TITLE
Add armhf release config for Eloquent.

### DIFF
--- a/eloquent/release-bionic-arm64-build.yaml
+++ b/eloquent/release-bionic-arm64-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_label: buildagent_arm64 || eloquent_binarydeb_ubv8
-jenkins_binary_job_priority: 78
+jenkins_binary_job_priority: 79
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 75
 jenkins_source_job_timeout: 30

--- a/eloquent/release-bionic-arm64-build.yaml
+++ b/eloquent/release-bionic-arm64-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_label: buildagent_arm64 || eloquent_binarydeb_ubv8
-jenkins_binary_job_priority: 79
+jenkins_binary_job_priority: 78
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 75
 jenkins_source_job_timeout: 30

--- a/eloquent/release-bionic-armhf-build.yaml
+++ b/eloquent/release-bionic-armhf-build.yaml
@@ -3,7 +3,7 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_label: buildagent_armhf || eloquent_binarydeb_ubv8
-jenkins_binary_job_priority: 79
+jenkins_binary_job_priority: 99
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 75
 jenkins_source_job_timeout: 30

--- a/eloquent/release-bionic-armhf-build.yaml
+++ b/eloquent/release-bionic-armhf-build.yaml
@@ -1,75 +1,24 @@
 %YAML 1.1
-# ROS buildfarm index file
+# ROS buildfarm release-build file
 ---
-distributions:
-  crystal:
-    ci_builds:
-      nightly: crystal/ci-nightly.yaml
-      overlay: crystal/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-crystal@googlegroups.com
-    release_builds:
-      default: crystal/release-build.yaml
-      ubv8: crystal/release-bionic-arm64-build.yaml
-    source_builds:
-      default: crystal/source-build.yaml
-  dashing:
-    ci_builds:
-      nightly-connext: dashing/ci-nightly-connext.yaml
-      nightly-cyclonedds: dashing/ci-nightly-cyclonedds.yaml
-      nightly-debug: dashing/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: dashing/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: dashing/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: dashing/ci-nightly-fastrtps-dynamic.yaml
-      nightly-opensplice: dashing/ci-nightly-opensplice.yaml
-      nightly-release: dashing/ci-nightly-release.yaml
-      overlay: dashing/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-dashing@googlegroups.com
-    release_builds:
-      default: dashing/release-build.yaml
-      ubv8: dashing/release-bionic-arm64-build.yaml
-      ubhf: dashing/release-bionic-armhf-build.yaml
-    source_builds:
-      default: dashing/source-build.yaml
-  eloquent:
-    ci_builds:
-      nightly-connext: eloquent/ci-nightly-connext.yaml
-      nightly-cyclonedds: eloquent/ci-nightly-cyclonedds.yaml
-      nightly-debug: eloquent/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: eloquent/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: eloquent/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: eloquent/ci-nightly-fastrtps-dynamic.yaml
-      nightly-navigation2: eloquent/ci-nightly-navigation2.yaml
-      nightly-navigation2-prerequisites: eloquent/ci-nightly-navigation2-prerequisites.yaml
-      nightly-opensplice: eloquent/ci-nightly-opensplice.yaml
-      nightly-release: eloquent/ci-nightly-release.yaml
-      overlay: eloquent/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - michael+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-eloquent@googlegroups.com
-    release_builds:
-      default: eloquent/release-build.yaml
-      ubhf: eloquent/release-bionic-armhf-build.yaml
-      ubv8: eloquent/release-bionic-arm64-build.yaml
-    source_builds:
-      default: eloquent/source-build.yaml
-jenkins_url: http://build.ros2.org
-notification_emails:
-  - steven+build.ros2.org@openrobotics.org
-prerequisites:
-  debian_repositories:
-  - http://repo.ros2.org/ubuntu/building
-  - http://repositories.ros.org/ubuntu/main
-  debian_repository_keys:
+abi_incompatibility_assumed: true
+jenkins_binary_job_label: buildagent_armhf || eloquent_binarydeb_ubv8
+jenkins_binary_job_priority: 79
+jenkins_binary_job_timeout: 720
+jenkins_source_job_priority: 75
+jenkins_source_job_timeout: 30
+notifications:
+  emails:
+  - michael+build.ros2.org@openrobotics.org
+  - ros2-buildfarm-eloquent@googlegroups.com
+  maintainers: true
+sync:
+  package_count: 3
+repositories:
+  keys:
   - |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
-    Version: GnuPGv1
+    Version: GnuPG v1
 
     mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
     VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
@@ -129,11 +78,14 @@ prerequisites:
     qYE=
     =Vgio
     -----END PGP PUBLIC KEY BLOCK-----
-rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
-status_page_repositories:
-  default:
-    - http://repo.ros2.org/ubuntu/building
-    - http://repo.ros2.org/ubuntu/testing
-    - http://repo.ros2.org/ubuntu/main
-type: buildfarm
-version: 1
+  urls:
+  - http://repo.ros2.org/ubuntu/building
+  - http://repositories.ros.org/ubuntu/main
+target_repository: http://repo.ros2.org/ubuntu/building
+targets:
+  ubuntu:
+    bionic:
+      armhf:
+type: release-build
+upload_credential_id: 1e7d4696-7fd4-4bc6-8c87-ebc7b6ce16e5
+version: 2

--- a/eloquent/release-build.yaml
+++ b/eloquent/release-build.yaml
@@ -6,7 +6,7 @@ abi_incompatibility_assumed: true
 build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 
-jenkins_binary_job_priority: 79
+jenkins_binary_job_priority: 78
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 75
 jenkins_source_job_timeout: 30

--- a/eloquent/release-build.yaml
+++ b/eloquent/release-build.yaml
@@ -6,7 +6,7 @@ abi_incompatibility_assumed: true
 build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 
-jenkins_binary_job_priority: 78
+jenkins_binary_job_priority: 79
 jenkins_binary_job_timeout: 120
 jenkins_source_job_priority: 75
 jenkins_source_job_timeout: 30


### PR DESCRIPTION
To add this config I've slightly increased the priority of non-armhf eloquent binaries.

For ROS 1 we've kept separate priority levels for each architecture. In
ROS 2 we haven't since we use arch-specific agents but as the armhf and
arm64 builds may share an arm host they now have to use distinct
priority levels

<details><summary>./list_priorities.py</summary>
<code><pre>
45
  jenkins_pull_request_job_priority::eloquent/source-build.yaml
46
  jenkins_pull_request_job_priority::dashing/source-build.yaml
47
  jenkins_pull_request_job_priority::crystal/source-build.yaml
50
  jenkins_job_priority::crystal/ci-nightly.yaml
  jenkins_job_priority::crystal/ci-overlay.yaml
  jenkins_job_priority::dashing/ci-nightly-connext.yaml
  jenkins_job_priority::dashing/ci-nightly-cyclonedds.yaml
  jenkins_job_priority::dashing/ci-nightly-debug.yaml
  jenkins_job_priority::dashing/ci-nightly-extra-rmw-release.yaml
  jenkins_job_priority::dashing/ci-nightly-fastrtps-dynamic.yaml
  jenkins_job_priority::dashing/ci-nightly-fastrtps.yaml
  jenkins_job_priority::dashing/ci-nightly-opensplice.yaml
  jenkins_job_priority::dashing/ci-nightly-release.yaml
  jenkins_job_priority::dashing/ci-overlay.yaml
  jenkins_job_priority::eloquent/ci-nightly-connext.yaml
  jenkins_job_priority::eloquent/ci-nightly-cyclonedds.yaml
  jenkins_job_priority::eloquent/ci-nightly-debug.yaml
  jenkins_job_priority::eloquent/ci-nightly-extra-rmw-release.yaml
  jenkins_job_priority::eloquent/ci-nightly-fastrtps-dynamic.yaml
  jenkins_job_priority::eloquent/ci-nightly-fastrtps.yaml
  jenkins_job_priority::eloquent/ci-nightly-navigation2-prerequisites.yaml
  jenkins_job_priority::eloquent/ci-nightly-navigation2.yaml
  jenkins_job_priority::eloquent/ci-nightly-opensplice.yaml
  jenkins_job_priority::eloquent/ci-nightly-release.yaml
  jenkins_job_priority::eloquent/ci-overlay.yaml
55
  jenkins_commit_job_priority::eloquent/source-build.yaml
56
  jenkins_commit_job_priority::dashing/source-build.yaml
57
  jenkins_commit_job_priority::crystal/source-build.yaml
75
  jenkins_source_job_priority::eloquent/release-bionic-arm64-build.yaml
  jenkins_source_job_priority::eloquent/release-bionic-armhf-build.yaml
  jenkins_source_job_priority::eloquent/release-build.yaml
76
  jenkins_source_job_priority::dashing/release-bionic-arm64-build.yaml
  jenkins_source_job_priority::dashing/release-bionic-armhf-build.yaml
  jenkins_source_job_priority::dashing/release-build.yaml
77
  jenkins_source_job_priority::crystal/release-bionic-arm64-build.yaml
  jenkins_source_job_priority::crystal/release-build.yaml
78
  jenkins_binary_job_priority::eloquent/release-bionic-arm64-build.yaml
  jenkins_binary_job_priority::eloquent/release-build.yaml
79
  jenkins_binary_job_priority::eloquent/release-bionic-armhf-build.yaml
80
  jenkins_binary_job_priority::dashing/release-bionic-arm64-build.yaml
  jenkins_binary_job_priority::dashing/release-build.yaml
81
  jenkins_binary_job_priority::crystal/release-bionic-arm64-build.yaml
  jenkins_binary_job_priority::crystal/release-build.yaml
99
  jenkins_binary_job_priority::dashing/release-bionic-armhf-build.yaml
</pre></code></details>