### PR TITLE
Skip cyclonedds_vendor until upstream issues are resolved

### DIFF
--- a/dashing/ci-nightly-cyclonedds.yaml
+++ b/dashing/ci-nightly-cyclonedds.yaml
@@ -25,7 +25,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore-regex .*connext.* .*fastrtps.* .*opensplice.*'
+package_selection_args: '--packages-ignore-regex .*connext.* .*fastrtps.* .*opensplice.* --packages-skip cyclonedds_vendor'
 repos_files:
 - https://github.com/ros2/ros2/raw/dashing/ros2.repos
 - https://github.com/ros2/ros2/raw/dashing/cyclonedds.repos

--- a/eloquent/ci-nightly-cyclonedds.yaml
+++ b/eloquent/ci-nightly-cyclonedds.yaml
@@ -25,7 +25,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore-regex .*connext.* .*fastrtps.* .*opensplice.*'
+package_selection_args: '--packages-ignore-regex .*connext.* .*fastrtps.* .*opensplice.* --packages-skip cyclonedds_vendor'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 - https://github.com/ros2/ros2/raw/master/cyclonedds.repos


### PR DESCRIPTION
See discussion in atolab/rmw_cyclonedds#34

Should get the CycloneDDS jobs passing.
Example failure: [![Build Status](http://build.ros2.org/buildStatus/icon?job=Dci__nightly-cyclonedds_ubuntu_bionic_amd64&build=32)](http://build.ros2.org/view/Dci/job/Dci__nightly-cyclonedds_ubuntu_bionic_amd64/32/)