### PR TITLE
Add Eloquent perfomance tests

### DIFF
--- a/eloquent/ci-nightly-performance-arm64.yaml
+++ b/eloquent/ci-nightly-performance-arm64.yaml
@@ -1,78 +1,39 @@
 %YAML 1.1
-# ROS buildfarm index file
+# ROS buildfarm ci-build file
 ---
-distributions:
-  crystal:
-    ci_builds:
-      nightly: crystal/ci-nightly.yaml
-      overlay: crystal/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-crystal@googlegroups.com
-    release_builds:
-      default: crystal/release-build.yaml
-      ubv8: crystal/release-bionic-arm64-build.yaml
-    source_builds:
-      default: crystal/source-build.yaml
-  dashing:
-    ci_builds:
-      nightly-connext: dashing/ci-nightly-connext.yaml
-      nightly-cyclonedds: dashing/ci-nightly-cyclonedds.yaml
-      nightly-debug: dashing/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: dashing/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: dashing/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: dashing/ci-nightly-fastrtps-dynamic.yaml
-      nightly-opensplice: dashing/ci-nightly-opensplice.yaml
-      nightly-release: dashing/ci-nightly-release.yaml
-      overlay: dashing/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-dashing@googlegroups.com
-    release_builds:
-      default: dashing/release-build.yaml
-      ubv8: dashing/release-bionic-arm64-build.yaml
-      ubhf: dashing/release-bionic-armhf-build.yaml
-    source_builds:
-      default: dashing/source-build.yaml
-  eloquent:
-    ci_builds:
-      nightly-connext: eloquent/ci-nightly-connext.yaml
-      nightly-cyclonedds: eloquent/ci-nightly-cyclonedds.yaml
-      nightly-debug: eloquent/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: eloquent/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: eloquent/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: eloquent/ci-nightly-fastrtps-dynamic.yaml
-      nightly-navigation2: eloquent/ci-nightly-navigation2.yaml
-      nightly-navigation2-prerequisites: eloquent/ci-nightly-navigation2-prerequisites.yaml
-      nightly-opensplice: eloquent/ci-nightly-opensplice.yaml
-      nightly-performance: eloquent/ci-nightly-performance.yaml
-      nightly-performance-arm64: eloquent/ci-nightly-performance-arm64.yaml
-      nightly-performance-prerequisites: eloquent/ci-nightly-performance-prerequisites.yaml
-      nightly-release: eloquent/ci-nightly-release.yaml
-      overlay: eloquent/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - michael+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-eloquent@googlegroups.com
-    release_builds:
-      default: eloquent/release-build.yaml
-      ubhf: eloquent/release-bionic-armhf-build.yaml
-      ubv8: eloquent/release-bionic-arm64-build.yaml
-    source_builds:
-      default: eloquent/source-build.yaml
-jenkins_url: http://build.ros2.org
-notification_emails:
-  - steven+build.ros2.org@openrobotics.org
-prerequisites:
-  debian_repositories:
-  - http://repo.ros2.org/ubuntu/building
-  - http://repositories.ros.org/ubuntu/main
-  debian_repository_keys:
+build_environment_variables:
+  CMAKE_PREFIX_PATH: '/opt/ros/melodic:$CMAKE_PREFIX_PATH'
+  LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
+  PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
+  ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
+  ROS_PYTHON_VERSION: '3'
+build_tool: colcon
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+install_packages:
+- default-jdk # for CycloneDDS
+- libasio-dev # for FastRTPS
+- libtinyxml2-dev # for FastRTPS
+- maven # for CycloneDDS
+- ros-melodic-common-msgs
+- ros-melodic-rosbash
+- ros-melodic-roscpp
+- ros-melodic-roscpp-tutorials
+- ros-melodic-roslaunch
+- ros-melodic-rosmsg
+- ros-melodic-rospy-tutorials
+- ros-melodic-tf2-msgs
+jenkins_job_label: buildagent_arm64
+jenkins_job_priority: 50
+jenkins_job_timeout: 60
+jenkins_job_upstream_triggers:
+- nightly-performance-prerequisites
+repos_files:
+- https://gist.githubusercontent.com/cottsay/d3ed9d3c7ed32165fdb987a09d434661/raw/ros2.repos
+repositories:
+  keys:
   - |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
-    Version: GnuPGv1
+    Version: GnuPG v1
 
     mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
     VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
@@ -132,11 +93,17 @@ prerequisites:
     qYE=
     =Vgio
     -----END PGP PUBLIC KEY BLOCK-----
-rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
-status_page_repositories:
-  default:
-    - http://repo.ros2.org/ubuntu/building
-    - http://repo.ros2.org/ubuntu/testing
-    - http://repo.ros2.org/ubuntu/main
-type: buildfarm
+  urls:
+  - http://repo.ros2.org/ubuntu/testing
+  - http://repositories.ros.org/ubuntu/main
+targets:
+  ubuntu:
+    bionic:
+      arm64:
+type: ci-build
+underlay_from_ci_jobs:
+- nightly-performance-prerequisites
+show_images:
+  Performance Test Results:
+  - ws/test_results/buildfarm_perf_tests/performance_test_results_*.png
 version: 1

--- a/eloquent/ci-nightly-performance-arm64.yaml
+++ b/eloquent/ci-nightly-performance-arm64.yaml
@@ -28,7 +28,7 @@ jenkins_job_timeout: 90
 jenkins_job_upstream_triggers:
 - nightly-performance-prerequisites
 repos_files:
-- https://gist.githubusercontent.com/cottsay/d3ed9d3c7ed32165fdb987a09d434661/raw/ros2.repos
+- https://github.com/ros2/buildfarm_perf_tests/raw/master/tools/ros2_dependencies.repos
 repositories:
   keys:
   - |

--- a/eloquent/ci-nightly-performance-arm64.yaml
+++ b/eloquent/ci-nightly-performance-arm64.yaml
@@ -24,7 +24,7 @@ install_packages:
 - ros-melodic-tf2-msgs
 jenkins_job_label: buildagent_arm64
 jenkins_job_priority: 50
-jenkins_job_timeout: 60
+jenkins_job_timeout: 90
 jenkins_job_upstream_triggers:
 - nightly-performance-prerequisites
 repos_files:

--- a/eloquent/ci-nightly-performance-prerequisites.yaml
+++ b/eloquent/ci-nightly-performance-prerequisites.yaml
@@ -29,7 +29,7 @@ jenkins_job_timeout: 300
 package_selection_args: '--packages-up-to buildfarm_perf_tests --packages-skip performance_test buildfarm_perf_tests --packages-skip-regex .*connext.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
-- https://gist.githubusercontent.com/cottsay/d3ed9d3c7ed32165fdb987a09d434661/raw/ros2.repos
+- https://github.com/ros2/buildfarm_perf_tests/raw/master/tools/ros2_dependencies.repos
 repositories:
   keys:
   - |

--- a/eloquent/ci-nightly-performance-prerequisites.yaml
+++ b/eloquent/ci-nightly-performance-prerequisites.yaml
@@ -1,78 +1,40 @@
 %YAML 1.1
-# ROS buildfarm index file
+# ROS buildfarm ci-build file
 ---
-distributions:
-  crystal:
-    ci_builds:
-      nightly: crystal/ci-nightly.yaml
-      overlay: crystal/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-crystal@googlegroups.com
-    release_builds:
-      default: crystal/release-build.yaml
-      ubv8: crystal/release-bionic-arm64-build.yaml
-    source_builds:
-      default: crystal/source-build.yaml
-  dashing:
-    ci_builds:
-      nightly-connext: dashing/ci-nightly-connext.yaml
-      nightly-cyclonedds: dashing/ci-nightly-cyclonedds.yaml
-      nightly-debug: dashing/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: dashing/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: dashing/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: dashing/ci-nightly-fastrtps-dynamic.yaml
-      nightly-opensplice: dashing/ci-nightly-opensplice.yaml
-      nightly-release: dashing/ci-nightly-release.yaml
-      overlay: dashing/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-dashing@googlegroups.com
-    release_builds:
-      default: dashing/release-build.yaml
-      ubv8: dashing/release-bionic-arm64-build.yaml
-      ubhf: dashing/release-bionic-armhf-build.yaml
-    source_builds:
-      default: dashing/source-build.yaml
-  eloquent:
-    ci_builds:
-      nightly-connext: eloquent/ci-nightly-connext.yaml
-      nightly-cyclonedds: eloquent/ci-nightly-cyclonedds.yaml
-      nightly-debug: eloquent/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: eloquent/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: eloquent/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: eloquent/ci-nightly-fastrtps-dynamic.yaml
-      nightly-navigation2: eloquent/ci-nightly-navigation2.yaml
-      nightly-navigation2-prerequisites: eloquent/ci-nightly-navigation2-prerequisites.yaml
-      nightly-opensplice: eloquent/ci-nightly-opensplice.yaml
-      nightly-performance: eloquent/ci-nightly-performance.yaml
-      nightly-performance-arm64: eloquent/ci-nightly-performance-arm64.yaml
-      nightly-performance-prerequisites: eloquent/ci-nightly-performance-prerequisites.yaml
-      nightly-release: eloquent/ci-nightly-release.yaml
-      overlay: eloquent/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - michael+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-eloquent@googlegroups.com
-    release_builds:
-      default: eloquent/release-build.yaml
-      ubhf: eloquent/release-bionic-armhf-build.yaml
-      ubv8: eloquent/release-bionic-arm64-build.yaml
-    source_builds:
-      default: eloquent/source-build.yaml
-jenkins_url: http://build.ros2.org
-notification_emails:
-  - steven+build.ros2.org@openrobotics.org
-prerequisites:
-  debian_repositories:
-  - http://repo.ros2.org/ubuntu/building
-  - http://repositories.ros.org/ubuntu/main
-  debian_repository_keys:
+build_environment_variables:
+  CMAKE_PREFIX_PATH: '/opt/ros/melodic:$CMAKE_PREFIX_PATH'
+  LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
+  PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
+  ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
+  ROS_PYTHON_VERSION: '3'
+build_tool: colcon
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+install_packages:
+- default-jdk # for CycloneDDS
+- libasio-dev # for FastRTPS
+- libtinyxml2-dev # for FastRTPS
+- maven # for CycloneDDS
+- ros-melodic-common-msgs
+- ros-melodic-rosbash
+- ros-melodic-roscpp
+- ros-melodic-roscpp-tutorials
+- ros-melodic-roslaunch
+- ros-melodic-rosmsg
+- ros-melodic-rospy-tutorials
+- ros-melodic-tf2-msgs
+jenkins_job_label: buildagent_arm64
+jenkins_job_priority: 50
+jenkins_job_schedule: 15 23 * * *
+jenkins_job_timeout: 300
+package_selection_args: '--packages-up-to buildfarm_perf_tests --packages-skip performance_test buildfarm_perf_tests --packages-skip-regex .*connext.*'
+repos_files:
+- https://github.com/ros2/ros2/raw/master/ros2.repos
+- https://gist.githubusercontent.com/cottsay/d3ed9d3c7ed32165fdb987a09d434661/raw/ros2.repos
+repositories:
+  keys:
   - |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
-    Version: GnuPGv1
+    Version: GnuPG v1
 
     mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
     VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
@@ -132,11 +94,12 @@ prerequisites:
     qYE=
     =Vgio
     -----END PGP PUBLIC KEY BLOCK-----
-rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
-status_page_repositories:
-  default:
-    - http://repo.ros2.org/ubuntu/building
-    - http://repo.ros2.org/ubuntu/testing
-    - http://repo.ros2.org/ubuntu/main
-type: buildfarm
+  urls:
+  - http://repo.ros2.org/ubuntu/testing
+  - http://repositories.ros.org/ubuntu/main
+targets:
+  ubuntu:
+    bionic:
+      arm64:
+type: ci-build
 version: 1

--- a/eloquent/ci-nightly-performance.yaml
+++ b/eloquent/ci-nightly-performance.yaml
@@ -112,6 +112,7 @@ show_plots:
   Performance Test Results:
   - title: Average Round-Trip Time
     y_axis_label: Milliseconds
+    master_csv_name: plot-6509911700247260954.csv
     style: line
     y_axis_exclude_zero: False
     data_series:
@@ -122,6 +123,7 @@ show_plots:
       url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
   - title: Max Resident Set Size
     y_axis_label: Megabytes
+    master_csv_name: plot-8724667824625016735.csv
     style: line
     y_axis_exclude_zero: True
     data_series:

--- a/eloquent/ci-nightly-performance.yaml
+++ b/eloquent/ci-nightly-performance.yaml
@@ -30,7 +30,7 @@ jenkins_job_timeout: 60
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
 repos_files:
-- https://gist.githubusercontent.com/cottsay/d3ed9d3c7ed32165fdb987a09d434661/raw/ros2.repos
+- https://github.com/ros2/buildfarm_perf_tests/raw/master/tools/ros2_dependencies.repos
 repositories:
   keys:
   - |

--- a/eloquent/ci-nightly-performance.yaml
+++ b/eloquent/ci-nightly-performance.yaml
@@ -108,4 +108,26 @@ underlay_from_ci_jobs:
 show_images:
   Performance Test Results:
   - ws/test_results/buildfarm_perf_tests/performance_test_results_*.png
+show_plots:
+  Performance Test Results:
+  - title: Average Round-Trip Time
+    y_axis_label: Milliseconds
+    style: line
+    y_axis_exclude_zero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Max Resident Set Size
+    y_axis_label: Megabytes
+    style: line
+    y_axis_exclude_zero: True
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 1
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
 version: 1

--- a/eloquent/ci-nightly-performance.yaml
+++ b/eloquent/ci-nightly-performance.yaml
@@ -1,78 +1,41 @@
 %YAML 1.1
-# ROS buildfarm index file
+# ROS buildfarm ci-build file
 ---
-distributions:
-  crystal:
-    ci_builds:
-      nightly: crystal/ci-nightly.yaml
-      overlay: crystal/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-crystal@googlegroups.com
-    release_builds:
-      default: crystal/release-build.yaml
-      ubv8: crystal/release-bionic-arm64-build.yaml
-    source_builds:
-      default: crystal/source-build.yaml
-  dashing:
-    ci_builds:
-      nightly-connext: dashing/ci-nightly-connext.yaml
-      nightly-cyclonedds: dashing/ci-nightly-cyclonedds.yaml
-      nightly-debug: dashing/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: dashing/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: dashing/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: dashing/ci-nightly-fastrtps-dynamic.yaml
-      nightly-opensplice: dashing/ci-nightly-opensplice.yaml
-      nightly-release: dashing/ci-nightly-release.yaml
-      overlay: dashing/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - steven+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-dashing@googlegroups.com
-    release_builds:
-      default: dashing/release-build.yaml
-      ubv8: dashing/release-bionic-arm64-build.yaml
-      ubhf: dashing/release-bionic-armhf-build.yaml
-    source_builds:
-      default: dashing/source-build.yaml
-  eloquent:
-    ci_builds:
-      nightly-connext: eloquent/ci-nightly-connext.yaml
-      nightly-cyclonedds: eloquent/ci-nightly-cyclonedds.yaml
-      nightly-debug: eloquent/ci-nightly-debug.yaml
-      nightly-extra-rmw-release: eloquent/ci-nightly-extra-rmw-release.yaml
-      nightly-fastrtps: eloquent/ci-nightly-fastrtps.yaml
-      nightly-fastrtps-dynamic: eloquent/ci-nightly-fastrtps-dynamic.yaml
-      nightly-navigation2: eloquent/ci-nightly-navigation2.yaml
-      nightly-navigation2-prerequisites: eloquent/ci-nightly-navigation2-prerequisites.yaml
-      nightly-opensplice: eloquent/ci-nightly-opensplice.yaml
-      nightly-performance: eloquent/ci-nightly-performance.yaml
-      nightly-performance-arm64: eloquent/ci-nightly-performance-arm64.yaml
-      nightly-performance-prerequisites: eloquent/ci-nightly-performance-prerequisites.yaml
-      nightly-release: eloquent/ci-nightly-release.yaml
-      overlay: eloquent/ci-overlay.yaml
-    doc_builds: {}
-    notification_emails:
-      - michael+build.ros2.org@openrobotics.org
-      - ros2-buildfarm-eloquent@googlegroups.com
-    release_builds:
-      default: eloquent/release-build.yaml
-      ubhf: eloquent/release-bionic-armhf-build.yaml
-      ubv8: eloquent/release-bionic-arm64-build.yaml
-    source_builds:
-      default: eloquent/source-build.yaml
-jenkins_url: http://build.ros2.org
-notification_emails:
-  - steven+build.ros2.org@openrobotics.org
-prerequisites:
-  debian_repositories:
-  - http://repo.ros2.org/ubuntu/building
-  - http://repositories.ros.org/ubuntu/main
-  debian_repository_keys:
+build_environment_variables:
+  CMAKE_PREFIX_PATH: '/opt/ros/melodic:$CMAKE_PREFIX_PATH'
+  LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
+  NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
+  PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
+  ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
+  ROS_PYTHON_VERSION: '3'
+  RTI_NC_LICENSE_ACCEPTED: 'yes'
+build_tool: colcon
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+install_packages:
+- default-jdk # for CycloneDDS
+- libasio-dev # for FastRTPS
+- libtinyxml2-dev # for FastRTPS
+- maven # for CycloneDDS
+- ros-melodic-common-msgs
+- ros-melodic-rosbash
+- ros-melodic-roscpp
+- ros-melodic-roscpp-tutorials
+- ros-melodic-roslaunch
+- ros-melodic-rosmsg
+- ros-melodic-rospy-tutorials
+- ros-melodic-tf2-msgs
+jenkins_job_label: ci-agent
+jenkins_job_priority: 50
+jenkins_job_timeout: 60
+jenkins_job_upstream_triggers:
+- nightly-extra-rmw-release
+repos_files:
+- https://gist.githubusercontent.com/cottsay/d3ed9d3c7ed32165fdb987a09d434661/raw/ros2.repos
+repositories:
+  keys:
   - |
     -----BEGIN PGP PUBLIC KEY BLOCK-----
-    Version: GnuPGv1
+    Version: GnuPG v1
 
     mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
     VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
@@ -132,11 +95,17 @@ prerequisites:
     qYE=
     =Vgio
     -----END PGP PUBLIC KEY BLOCK-----
-rosdistro_index_url: https://raw.githubusercontent.com/ros/rosdistro/master/index-v4.yaml
-status_page_repositories:
-  default:
-    - http://repo.ros2.org/ubuntu/building
-    - http://repo.ros2.org/ubuntu/testing
-    - http://repo.ros2.org/ubuntu/main
-type: buildfarm
+  urls:
+  - http://repo.ros2.org/ubuntu/testing
+  - http://repositories.ros.org/ubuntu/main
+targets:
+  ubuntu:
+    bionic:
+      amd64:
+type: ci-build
+underlay_from_ci_jobs:
+- nightly-extra-rmw-release
+show_images:
+  Performance Test Results:
+  - ws/test_results/buildfarm_perf_tests/performance_test_results_*.png
 version: 1


### PR DESCRIPTION
I'm going to open some pull request to start discussing and merging upstream the performance tests that @cottsay has developed.

Potentials TODO task:
 - This PR includes 3 new jobs, one of them with prerequisites of the test and other one just with the tests. Maybe it makes sense to include everything in the same job.
 - These performance tests need two repos defined [here](https://gist.githubusercontent.com/cottsay/d3ed9d3c7ed32165fdb987a09d434661/raw/ros2.repos)
   - [buildfarm_perf_tests]( https://github.com/cottsay/buildfarm_perf_tests.git) This repo contains the tests. With the results of these tests we will create the plots.
       - **Where we should locate this repo?**
               - Should we create on new repo in osrf?
               - Should we try to merge this in Apex.AI performance_test repo?
   - [performance_test](https://gitlab.com/cottsay/performance_test.git). Right now @cottsay has it own fork because there are two pending PRs:
                - https://gitlab.com/ApexAI/performance_test/merge_requests/121
                - https://gitlab.com/ApexAI/performance_test/merge_requests/129

Related PR https://github.com/ros-infrastructure/ros_buildfarm/pull/689

## Jenkings Plugin
 - [plot-plugin](https://github.com/jenkinsci/plot-plugin)
 - [image-gallery-plugin](https://github.com/jenkinsci/image-gallery-plugin)

## Documentation
 - [How to run the tests locally](https://github.com/cottsay/buildfarm_perf_tests/pull/2)