### PR TITLE
Update eloquent repos to use release branch

### DIFF
--- a/eloquent/ci-nightly-connext.yaml
+++ b/eloquent/ci-nightly-connext.yaml
@@ -26,7 +26,7 @@ jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*cyclonedds.* .*fastrtps.* .*opensplice.*'
 repos_files:
-- https://github.com/ros2/ros2/raw/master/ros2.repos
+- https://github.com/ros2/ros2/raw/eloquent/ros2.repos
 repositories:
   keys:
   - |

--- a/eloquent/ci-nightly-cyclonedds.yaml
+++ b/eloquent/ci-nightly-cyclonedds.yaml
@@ -26,7 +26,7 @@ jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*fastrtps.* .*opensplice.*'
 repos_files:
-- https://github.com/ros2/ros2/raw/master/ros2.repos
+- https://github.com/ros2/ros2/raw/eloquent/ros2.repos
 repositories:
   keys:
   - |

--- a/eloquent/ci-nightly-debug.yaml
+++ b/eloquent/ci-nightly-debug.yaml
@@ -28,7 +28,7 @@ jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*cyclonedds.* .*opensplice.*'
 repos_files:
-- https://github.com/ros2/ros2/raw/master/ros2.repos
+- https://github.com/ros2/ros2/raw/eloquent/ros2.repos
 repositories:
   keys:
   - |

--- a/eloquent/ci-nightly-extra-rmw-release.yaml
+++ b/eloquent/ci-nightly-extra-rmw-release.yaml
@@ -29,7 +29,7 @@ jenkins_job_priority: 48
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
 repos_files:
-- https://github.com/ros2/ros2/raw/master/ros2.repos
+- https://github.com/ros2/ros2/raw/eloquent/ros2.repos
 repositories:
   keys:
   - |

--- a/eloquent/ci-nightly-fastrtps-dynamic.yaml
+++ b/eloquent/ci-nightly-fastrtps-dynamic.yaml
@@ -26,7 +26,7 @@ jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.* .*opensplice.*'
 repos_files:
-- https://github.com/ros2/ros2/raw/master/ros2.repos
+- https://github.com/ros2/ros2/raw/eloquent/ros2.repos
 repositories:
   keys:
   - |

--- a/eloquent/ci-nightly-fastrtps.yaml
+++ b/eloquent/ci-nightly-fastrtps.yaml
@@ -26,7 +26,7 @@ jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.* .*opensplice.*'
 repos_files:
-- https://github.com/ros2/ros2/raw/master/ros2.repos
+- https://github.com/ros2/ros2/raw/eloquent/ros2.repos
 repositories:
   keys:
   - |

--- a/eloquent/ci-nightly-opensplice.yaml
+++ b/eloquent/ci-nightly-opensplice.yaml
@@ -24,7 +24,7 @@ jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.* .*fastrtps.*'
 repos_files:
-- https://github.com/ros2/ros2/raw/master/ros2.repos
+- https://github.com/ros2/ros2/raw/eloquent/ros2.repos
 repositories:
   keys:
   - |

--- a/eloquent/ci-nightly-release.yaml
+++ b/eloquent/ci-nightly-release.yaml
@@ -28,7 +28,7 @@ jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*cyclonedds.* .*opensplice.*'
 repos_files:
-- https://github.com/ros2/ros2/raw/master/ros2.repos
+- https://github.com/ros2/ros2/raw/eloquent/ros2.repos
 repositories:
   keys:
   - |

--- a/eloquent/ci-overlay.yaml
+++ b/eloquent/ci-overlay.yaml
@@ -27,7 +27,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 48
 jenkins_job_timeout: 240
 repos_files:
-- https://github.com/ros2/ros2/raw/master/ros2.repos
+- https://github.com/ros2/ros2/raw/eloquent/ros2.repos
 repositories:
   keys:
   - |


### PR DESCRIPTION
We were incorrectly tracking master `Foxy`, this sets the repos file to the released list of branches for `eloquent`