### PR TITLE
Reduce Foxy package counts

### DIFF
--- a/foxy/release-build.yaml
+++ b/foxy/release-build.yaml
@@ -16,7 +16,7 @@ notifications:
   - ros2-buildfarm-foxy@googlegroups.com
   maintainers: true
 sync:
-  package_count: 290
+  package_count: 3
 repositories:
   keys:
   - |

--- a/foxy/release-focal-arm64-build.yaml
+++ b/foxy/release-focal-arm64-build.yaml
@@ -13,7 +13,7 @@ notifications:
   - ros2-buildfarm-foxy@googlegroups.com
   maintainers: true
 sync:
-  package_count: 290
+  package_count: 3
 repositories:
   keys:
   - |

--- a/foxy/release-focal-armhf-build.yaml
+++ b/foxy/release-focal-armhf-build.yaml
@@ -13,7 +13,7 @@ notifications:
   - ros2-buildfarm-foxy@googlegroups.com
   maintainers: true
 sync:
-  package_count: 290
+  package_count: 3
 repositories:
   keys:
   - |


### PR DESCRIPTION
This is to get the buildfarm CI jobs to start passing.