### PR TITLE
Restrict access to in-development performance tests

### DIFF
--- a/dashing/ci-nightly-performance.yaml
+++ b/dashing/ci-nightly-performance.yaml
@@ -1142,4 +1142,22 @@ show_plots:
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 8
       url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_cpu_usage.png
+project_authorization_xml: |
+    <inheritanceStrategy class="org.jenkinsci.plugins.matrixauth.inheritance.NonInteritingStrategy"/>
+    <permission>com.cloudbees.plugins.credentials.CredentialsProvider.Update:ros*buildfarm-admins</permission>
+    <permission>com.cloudbees.plugins.credentials.CredentialsProvider.View:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Build:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Cancel:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Configure:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Delete:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Discover:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Move:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Read:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Read:ros2*performance-jobs</permission>
+    <permission>hudson.model.Item.ViewStatus:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Workspace:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Run.Delete:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Run.Replay:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Run.Update:ros*buildfarm-admins</permission>
+    <permission>hudson.scm.SCM.Tag:ros*buildfarm-admins</permission>
 version: 1

--- a/eloquent/ci-nightly-performance.yaml
+++ b/eloquent/ci-nightly-performance.yaml
@@ -1142,4 +1142,22 @@ show_plots:
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 8
       url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_cpu_usage.png
+project_authorization_xml: |
+    <inheritanceStrategy class="org.jenkinsci.plugins.matrixauth.inheritance.NonInteritingStrategy"/>
+    <permission>com.cloudbees.plugins.credentials.CredentialsProvider.Update:ros*buildfarm-admins</permission>
+    <permission>com.cloudbees.plugins.credentials.CredentialsProvider.View:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Build:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Cancel:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Configure:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Delete:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Discover:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Move:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Read:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Read:ros2*performance-jobs</permission>
+    <permission>hudson.model.Item.ViewStatus:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Item.Workspace:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Run.Delete:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Run.Replay:ros*buildfarm-admins</permission>
+    <permission>hudson.model.Run.Update:ros*buildfarm-admins</permission>
+    <permission>hudson.scm.SCM.Tag:ros*buildfarm-admins</permission>
 version: 1


### PR DESCRIPTION
Requires https://github.com/ros-infrastructure/ros_buildfarm/pull/737

Restricts access to the performance tests.