### PR TITLE
Adding latency and throughput for multisize packets

### DIFF
--- a/dashing/ci-nightly-performance.yaml
+++ b/dashing/ci-nightly-performance.yaml
@@ -258,6 +258,199 @@ show_plots:
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 5
       url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_cpu_usage.png
+  Performance One Process Test Results (multisize packets):
+  - title: Latency Average Round-Trip Time (Array1k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-8939547722037472502.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array4k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-7908744119021690936.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array16k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-1052760167688545959.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array32k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-7717983713042792899.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array60k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-7396137828978658268.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (PointCloud512k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-2157008091733438588.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array1m)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-2268123172353997031.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array2m)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-5156010586314063065.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Throughput (Array1k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-3612353787559171774.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array4k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-6444975328708407682.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array16k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-2082171328297330335.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array32k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-8618504082986290727.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array60k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-7806202233711422264.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (PointCloud512k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-6184023651158656891.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array1m)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-2777865377287333281.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array2m)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-9224278164751256763.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
   Overhead simple publisher and subscriber - Average Round-Trip Time:
   - title: Simple Pub rmw_fastrtps_cpp Average Round-Trip Time
     y_axis_label: Milliseconds
@@ -1170,6 +1363,199 @@ show_plots:
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 8
       url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_cpu_usage.png
+  Performance Two Processes Test Results (multisize packets):
+  - title: Latency Average Round-Trip Time (Array1k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-6904486870707929810.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array4k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-7084992488981114733.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array16k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-0893082430330187879.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array32k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-1398541136563376297.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array60k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-6058648695367179574.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (PointCloud512k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-8916286011498981299.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array1m)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-0775272024772458420.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array2m)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-7278194632225592369.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Throughput (Array1k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-5238938090774267741.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array4k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-9705366200748005823.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array16k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-8383904691490718586.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array32k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-0934813761407733537.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array60k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-8985422515004338280.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (PointCloud512k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-4982093187074015848.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array1m)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-7062706269082841405.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array2m)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-0081321398133037885.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Dci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
 project_authorization_xml: |
     <inheritanceStrategy class="org.jenkinsci.plugins.matrixauth.inheritance.NonInheritingStrategy"/>
     <permission>com.cloudbees.plugins.credentials.CredentialsProvider.Update:ros*buildfarm-admins</permission>

--- a/eloquent/ci-nightly-performance.yaml
+++ b/eloquent/ci-nightly-performance.yaml
@@ -258,6 +258,199 @@ show_plots:
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 5
       url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_cpu_usage.png
+  Performance One Process Test Results (multisize packets):
+  - title: Latency Average Round-Trip Time (Array1k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-8939547722037472502.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array4k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-7908744119021690936.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array16k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-1052760167688545959.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array32k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-7717983713042792899.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array60k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-7396137828978658268.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (PointCloud512k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-2157008091733438588.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array1m)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-2268123172353997031.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array2m)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-5156010586314063065.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%.png
+  - title: Throughput (Array1k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-3612353787559171774.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array4k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-6444975328708407682.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array16k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-2082171328297330335.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array32k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-8618504082986290727.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array60k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-7806202233711422264.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (PointCloud512k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-6184023651158656891.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array1m)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-2777865377287333281.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
+  - title: Throughput (Array2m)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-9224278164751256763.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_results_%name%_throughput.png
   Overhead simple publisher and subscriber - Average Round-Trip Time:
   - title: Simple Pub rmw_fastrtps_cpp Average Round-Trip Time
     y_axis_label: Milliseconds
@@ -1170,6 +1363,199 @@ show_plots:
       selection_flag: INCLUDE_BY_COLUMN
       selection_value: 8
       url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_cpu_usage.png
+  Performance Two Processes Test Results (multisize packets):
+  - title: Latency Average Round-Trip Time (Array1k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-6904486870707929810.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array4k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-7084992488981114733.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array16k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-0893082430330187879.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array32k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-1398541136563376297.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array60k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-6058648695367179574.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (PointCloud512k)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-8916286011498981299.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array1m)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-0775272024772458420.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Latency Average Round-Trip Time (Array2m)
+    y_axis_label: Milliseconds
+    master_csv_name: plot-7278194632225592369.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 0
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%.png
+  - title: Throughput (Array1k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-5238938090774267741.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array4k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-9705366200748005823.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array4k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array16k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-8383904691490718586.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array16k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array32k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-0934813761407733537.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array32k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array60k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-8985422515004338280.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array60k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (PointCloud512k)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-4982093187074015848.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_PointCloud512k.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array1m)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-7062706269082841405.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array1m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
+  - title: Throughput (Array2m)
+    y_axis_label: Mbits/s
+    master_csv_name: plot-0081321398133037885.csv
+    style: line
+    num_builds: 10
+    exclZero: False
+    data_series:
+    - data_file: ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*_Array2m.csv
+      data_type: csv
+      selection_flag: INCLUDE_BY_COLUMN
+      selection_value: 10
+      url: /job/Eci__nightly-performance_ubuntu_bionic_amd64/%build%/artifact/ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_%name%_throughput.png
 project_authorization_xml: |
     <inheritanceStrategy class="org.jenkinsci.plugins.matrixauth.inheritance.NonInheritingStrategy"/>
     <permission>com.cloudbees.plugins.credentials.CredentialsProvider.Update:ros*buildfarm-admins</permission>


### PR DESCRIPTION
Adding latency and throughput plots to compared these values between DDS vendors and packet sizes:

 - Array1k
 - Array4k
 - Array16k
 - Array32k
 - Array60k
 - PointCloud512k
 - Array1m
 - Array2m