### PR TITLE
enable CycloneDDS in debug/release builds

### DIFF
--- a/foxy/ci-nightly-debug.yaml
+++ b/foxy/ci-nightly-debug.yaml
@@ -12,8 +12,10 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug --no-warn-unused-cli'
 install_packages:
+- default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS
+- maven # for CycloneDDS
 # - ros-melodic-common-msgs
 # - ros-melodic-rosbash
 # - ros-melodic-roscpp
@@ -26,7 +28,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 47
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*cyclonedds.* .*opensplice.*'
+package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:

--- a/foxy/ci-nightly-release.yaml
+++ b/foxy/ci-nightly-release.yaml
@@ -12,8 +12,10 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 install_packages:
+- default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS
+- maven # for CycloneDDS
 # - ros-melodic-common-msgs
 # - ros-melodic-rosbash
 # - ros-melodic-roscpp
@@ -26,7 +28,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 47
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*cyclonedds.* .*opensplice.*'
+package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:


### PR DESCRIPTION
Since it is aiming to become tier-1 and we build it by default on ci.ros.org by now.