### PR TITLE
[foxy] separate cross vender tests from multi-rmw-jobs into downstream jobs

### DIFF
--- a/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -7,7 +7,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk # for CycloneDDS
 - maven # for CycloneDDS

--- a/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -2,33 +2,21 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-#   CMAKE_PREFIX_PATH: '/opt/ros/melodic:$CMAKE_PREFIX_PATH'
-#   LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
   NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
-#  PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
-#  ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
+  RMW_IMPLEMENTATIONS: 'rmw_connext_cpp:rmw_cyclonedds_cpp'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 install_packages:
 - default-jdk # for CycloneDDS
-- libasio-dev # for FastRTPS
-- libtinyxml2-dev # for FastRTPS
 - maven # for CycloneDDS
-# - ros-melodic-common-msgs
-# - ros-melodic-rosbash
-# - ros-melodic-roscpp
-# - ros-melodic-roscpp-tutorials
-# - ros-melodic-roslaunch
-# - ros-melodic-rosmsg
-# - ros-melodic-rospy-tutorials
-# - ros-melodic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 47
-jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore test_communication'
+jenkins_job_upstream_triggers:
+- nightly-release
+package_selection_args: '--paths src/ros2/system_tests/test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:
@@ -103,4 +91,6 @@ targets:
     focal:
       amd64:
 type: ci-build
+underlay_from_ci_jobs:
+- nightly-release
 version: 1

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -7,7 +7,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -2,33 +2,21 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-#   CMAKE_PREFIX_PATH: '/opt/ros/melodic:$CMAKE_PREFIX_PATH'
-#   LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
   NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
-#  PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
-#  ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
+  RMW_IMPLEMENTATIONS: 'rmw_connext_cpp:rmw_fastrtps_dynamic_cpp'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 install_packages:
-- default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS
-- maven # for CycloneDDS
-# - ros-melodic-common-msgs
-# - ros-melodic-rosbash
-# - ros-melodic-roscpp
-# - ros-melodic-roscpp-tutorials
-# - ros-melodic-roslaunch
-# - ros-melodic-rosmsg
-# - ros-melodic-rospy-tutorials
-# - ros-melodic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 47
-jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore test_communication'
+jenkins_job_upstream_triggers:
+- nightly-extra-rmw-release
+package_selection_args: '--paths src/ros2/system_tests/test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:
@@ -103,4 +91,6 @@ targets:
     focal:
       amd64:
 type: ci-build
+underlay_from_ci_jobs:
+- nightly-extra-rmw-release
 version: 1

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -7,7 +7,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -2,33 +2,21 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-#   CMAKE_PREFIX_PATH: '/opt/ros/melodic:$CMAKE_PREFIX_PATH'
-#   LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
   NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
-#  PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
-#  ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
+  RMW_IMPLEMENTATIONS: 'rmw_connext_cpp:rmw_fastrtps_cpp'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 install_packages:
-- default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS
-- maven # for CycloneDDS
-# - ros-melodic-common-msgs
-# - ros-melodic-rosbash
-# - ros-melodic-roscpp
-# - ros-melodic-roscpp-tutorials
-# - ros-melodic-roslaunch
-# - ros-melodic-rosmsg
-# - ros-melodic-rospy-tutorials
-# - ros-melodic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 47
-jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore test_communication'
+jenkins_job_upstream_triggers:
+- nightly-release
+package_selection_args: '--paths src/ros2/system_tests/test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:
@@ -103,4 +91,6 @@ targets:
     focal:
       amd64:
 type: ci-build
+underlay_from_ci_jobs:
+- nightly-release
 version: 1

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -2,13 +2,8 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-#   CMAKE_PREFIX_PATH: '/opt/ros/melodic:$CMAKE_PREFIX_PATH'
-#   LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
-  NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
-#  PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
-#  ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
+  RMW_IMPLEMENTATIONS: 'rmw_cyclonedds_cpp:rmw_fastrtps_dynamic_cpp'
   ROS_PYTHON_VERSION: '3'
-  RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 install_packages:
@@ -16,19 +11,12 @@ install_packages:
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS
 - maven # for CycloneDDS
-# - ros-melodic-common-msgs
-# - ros-melodic-rosbash
-# - ros-melodic-roscpp
-# - ros-melodic-roscpp-tutorials
-# - ros-melodic-roslaunch
-# - ros-melodic-rosmsg
-# - ros-melodic-rospy-tutorials
-# - ros-melodic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 47
-jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore test_communication'
+jenkins_job_upstream_triggers:
+- nightly-extra-rmw-release
+package_selection_args: '--paths src/ros2/system_tests/test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:
@@ -103,4 +91,6 @@ targets:
     focal:
       amd64:
 type: ci-build
+underlay_from_ci_jobs:
+- nightly-extra-rmw-release
 version: 1

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -5,7 +5,7 @@ build_environment_variables:
   RMW_IMPLEMENTATIONS: 'rmw_cyclonedds_cpp:rmw_fastrtps_dynamic_cpp'
   ROS_PYTHON_VERSION: '3'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -5,7 +5,7 @@ build_environment_variables:
   RMW_IMPLEMENTATIONS: 'rmw_cyclonedds_cpp:rmw_fastrtps_cpp'
   ROS_PYTHON_VERSION: '3'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -2,13 +2,8 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-#   CMAKE_PREFIX_PATH: '/opt/ros/melodic:$CMAKE_PREFIX_PATH'
-#   LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
-  NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
-#  PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
-#  ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
+  RMW_IMPLEMENTATIONS: 'rmw_cyclonedds_cpp:rmw_fastrtps_cpp'
   ROS_PYTHON_VERSION: '3'
-  RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 install_packages:
@@ -16,19 +11,12 @@ install_packages:
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS
 - maven # for CycloneDDS
-# - ros-melodic-common-msgs
-# - ros-melodic-rosbash
-# - ros-melodic-roscpp
-# - ros-melodic-roscpp-tutorials
-# - ros-melodic-roslaunch
-# - ros-melodic-rosmsg
-# - ros-melodic-rospy-tutorials
-# - ros-melodic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 47
-jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore test_communication'
+jenkins_job_upstream_triggers:
+- nightly-release
+package_selection_args: '--paths src/ros2/system_tests/test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:
@@ -103,4 +91,6 @@ targets:
     focal:
       amd64:
 type: ci-build
+underlay_from_ci_jobs:
+- nightly-release
 version: 1

--- a/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -5,7 +5,7 @@ build_environment_variables:
   RMW_IMPLEMENTATIONS: 'rmw_fastrtps_cpp:rmw_fastrtps_dynamic_cpp'
   ROS_PYTHON_VERSION: '3'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS

--- a/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -2,33 +2,19 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-#   CMAKE_PREFIX_PATH: '/opt/ros/melodic:$CMAKE_PREFIX_PATH'
-#   LD_LIBRARY_PATH: '/opt/ros/melodic/lib:$LD_LIBRARY_PATH'
-  NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
-#  PYTHONPATH: '/opt/ros/melodic/lib/python2.7/dist-packages:$PYTHONPATH'
-#  ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
+  RMW_IMPLEMENTATIONS: 'rmw_fastrtps_cpp:rmw_fastrtps_dynamic_cpp'
   ROS_PYTHON_VERSION: '3'
-  RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 install_packages:
-- default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS
-- maven # for CycloneDDS
-# - ros-melodic-common-msgs
-# - ros-melodic-rosbash
-# - ros-melodic-roscpp
-# - ros-melodic-roscpp-tutorials
-# - ros-melodic-roslaunch
-# - ros-melodic-rosmsg
-# - ros-melodic-rospy-tutorials
-# - ros-melodic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 47
-jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore test_communication'
+jenkins_job_upstream_triggers:
+- nightly-extra-rmw-release
+package_selection_args: '--paths src/ros2/system_tests/test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:
@@ -103,4 +89,6 @@ targets:
     focal:
       amd64:
 type: ci-build
+underlay_from_ci_jobs:
+- nightly-extra-rmw-release
 version: 1

--- a/foxy/ci-nightly-debug.yaml
+++ b/foxy/ci-nightly-debug.yaml
@@ -28,7 +28,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 47
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp test_communication'
+package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:

--- a/foxy/ci-nightly-debug.yaml
+++ b/foxy/ci-nightly-debug.yaml
@@ -10,7 +10,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug --no-warn-unused-cli'
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS

--- a/foxy/ci-nightly-debug.yaml
+++ b/foxy/ci-nightly-debug.yaml
@@ -28,7 +28,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 47
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
+package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:

--- a/foxy/ci-nightly-extra-rmw-release.yaml
+++ b/foxy/ci-nightly-extra-rmw-release.yaml
@@ -10,7 +10,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS

--- a/foxy/ci-nightly-extra-rmw-release.yaml
+++ b/foxy/ci-nightly-extra-rmw-release.yaml
@@ -28,7 +28,6 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 47
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:

--- a/foxy/ci-nightly-extra-rmw-release.yaml
+++ b/foxy/ci-nightly-extra-rmw-release.yaml
@@ -28,7 +28,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 47
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore test_communication'
+package_selection_args: '--packages-ignore'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:

--- a/foxy/ci-nightly-release.yaml
+++ b/foxy/ci-nightly-release.yaml
@@ -10,7 +10,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS

--- a/foxy/ci-nightly-release.yaml
+++ b/foxy/ci-nightly-release.yaml
@@ -28,7 +28,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 47
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp test_communication'
+package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:

--- a/foxy/ci-nightly-release.yaml
+++ b/foxy/ci-nightly-release.yaml
@@ -28,7 +28,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 47
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
-package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
+package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:

--- a/index.yaml
+++ b/index.yaml
@@ -51,6 +51,12 @@ distributions:
   foxy:
     ci_builds:
       nightly-connext: foxy/ci-nightly-connext.yaml
+      nightly-cross-vendor-connext-cyclonedds: foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+      nightly-cross-vendor-connext-fastrtps: foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
+      nightly-cross-vendor-connext-fastrtps-dynamic: foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+      nightly-cross-vendor-cyclonedds-fastrtps: foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+      nightly-cross-vendor-cyclonedds-fastrtps-dynamic: foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+      nightly-cross-vendor-fastrtps-fastrtps-dynamic: foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
       nightly-cyclonedds: foxy/ci-nightly-cyclonedds.yaml
       nightly-debug: foxy/ci-nightly-debug.yaml
       nightly-extra-rmw-release: foxy/ci-nightly-extra-rmw-release.yaml


### PR DESCRIPTION
This patch needs ros2/rmw#199 to select a subset of RMW implementations in the cross-vendor jobs.

Before this patch the `debug`, `release` and `extra-rmw` jobs were running the `test_communication` tests against all RMW impl. available in these jobs (Connext, CycloneDDS, FastRTPS for the first two, and additionally FastRTPS dynamic for the third). First, that makes it hard to see which exact cross vendor combination has problems if any. Second, it runs all these test sequentially which especially in case of failures can take a very long time.

This patch disables `test_communication` (which is atm the only package doing cross-vendor tests) for jobs with more than 1 RMW impl.

As a replacement it introduced downstream for every pair of RMW implementations. If both are tier-1 platforms it uses the archive produced by the `release` nightly. If at least one RMW is not tier-1 (only FastRTPS dynamic) it uses the `extra-rmw` nightly since only that one contains the non-tier-1 RMW.

This will allow to run all cross vendor tests in parallel without the need to rebuild all dependencies.