### PR TITLE
fix configuration of cross vendor jobs

### DIFF
--- a/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -3,6 +3,8 @@
 ---
 build_environment_variables:
   NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
+  # must override since the default has been removed from RMW_IMPLEMENTATIONS
+  RMW_IMPLEMENTATION: 'rmw_connext_cpp'
   RMW_IMPLEMENTATIONS: 'rmw_connext_cpp:rmw_cyclonedds_cpp'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
@@ -10,13 +12,14 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk # for CycloneDDS
+- libtinyxml2-dev # for FastRTPS, even though disabled it is needed for the typesupport
 - maven # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 47
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-release
-package_selection_args: '--paths src/ros2/system_tests/test_communication'
+package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -3,6 +3,8 @@
 ---
 build_environment_variables:
   NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
+  # must override since the default has been removed from RMW_IMPLEMENTATIONS
+  RMW_IMPLEMENTATION: 'rmw_connext_cpp'
   RMW_IMPLEMENTATIONS: 'rmw_connext_cpp:rmw_fastrtps_dynamic_cpp'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
@@ -16,7 +18,7 @@ jenkins_job_priority: 47
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
-package_selection_args: '--paths src/ros2/system_tests/test_communication'
+package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -16,7 +16,7 @@ jenkins_job_priority: 47
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-release
-package_selection_args: '--paths src/ros2/system_tests/test_communication'
+package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -2,8 +2,11 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
+  # must override since the default has been removed from RMW_IMPLEMENTATIONS
+  RMW_IMPLEMENTATION: 'rmw_cyclonedds_cpp'
   RMW_IMPLEMENTATIONS: 'rmw_cyclonedds_cpp:rmw_fastrtps_dynamic_cpp'
   ROS_PYTHON_VERSION: '3'
+  RTI_NC_LICENSE_ACCEPTED: 'yes'  # even thought not used installed for the underlay
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
@@ -16,7 +19,7 @@ jenkins_job_priority: 47
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
-package_selection_args: '--paths src/ros2/system_tests/test_communication'
+package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -4,6 +4,7 @@
 build_environment_variables:
   RMW_IMPLEMENTATIONS: 'rmw_cyclonedds_cpp:rmw_fastrtps_cpp'
   ROS_PYTHON_VERSION: '3'
+  RTI_NC_LICENSE_ACCEPTED: 'yes'  # even thought not used installed for the underlay
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
@@ -16,7 +17,7 @@ jenkins_job_priority: 47
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-release
-package_selection_args: '--paths src/ros2/system_tests/test_communication'
+package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:

--- a/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -4,6 +4,7 @@
 build_environment_variables:
   RMW_IMPLEMENTATIONS: 'rmw_fastrtps_cpp:rmw_fastrtps_dynamic_cpp'
   ROS_PYTHON_VERSION: '3'
+  RTI_NC_LICENSE_ACCEPTED: 'yes'  # even thought not used installed for the underlay
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
@@ -14,7 +15,7 @@ jenkins_job_priority: 47
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
-package_selection_args: '--paths src/ros2/system_tests/test_communication'
+package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:


### PR DESCRIPTION
Follow up of #78.

The remaining problem seems to be that `spdlog` isn't being exported which make it not installed in the overlay workspace. See ros2/rcl_logging#26.