### PR TITLE
Bump performance test job timeout from 2 => 3 hrs

### DIFF
--- a/dashing/ci-nightly-performance.yaml
+++ b/dashing/ci-nightly-performance.yaml
@@ -26,7 +26,7 @@ install_packages:
 - ros-melodic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 49
-jenkins_job_timeout: 120
+jenkins_job_timeout: 180
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
 repos_files:

--- a/eloquent/ci-nightly-performance.yaml
+++ b/eloquent/ci-nightly-performance.yaml
@@ -26,7 +26,7 @@ install_packages:
 - ros-melodic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 48
-jenkins_job_timeout: 120
+jenkins_job_timeout: 180
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
 repos_files:

--- a/foxy/ci-nightly-performance.yaml
+++ b/foxy/ci-nightly-performance.yaml
@@ -26,7 +26,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 48
-jenkins_job_timeout: 120
+jenkins_job_timeout: 180
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
 repos_files:


### PR DESCRIPTION
The separated sync/async tests nearly doubled the total test count.

FYI @ahcorde 