### PR TITLE
Keep performance CI jobs' CSV output as build artifacts.

### DIFF
--- a/foxy/ci-nightly-performance.yaml
+++ b/foxy/ci-nightly-performance.yaml
@@ -106,10 +106,10 @@ type: ci-build
 underlay_from_ci_jobs:
 - nightly-extra-rmw-release
 archive_files:
-  - ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv
-  - ws/test_results/buildfarm_perf_tests/overhead_test_results_*.csv
-  - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv
-  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.csv
+- ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv
+- ws/test_results/buildfarm_perf_tests/overhead_test_results_*.csv
+- ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv
+- ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.csv
 show_images:
   Performance Test Results:
   - ws/test_results/buildfarm_perf_tests/performance_test_results_*.png

--- a/foxy/ci-nightly-performance.yaml
+++ b/foxy/ci-nightly-performance.yaml
@@ -105,6 +105,11 @@ targets:
 type: ci-build
 underlay_from_ci_jobs:
 - nightly-extra-rmw-release
+keep_files:
+  - ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_*.csv
+  - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv
+  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.csv
 show_images:
   Performance Test Results:
   - ws/test_results/buildfarm_perf_tests/performance_test_results_*.png

--- a/foxy/ci-nightly-performance.yaml
+++ b/foxy/ci-nightly-performance.yaml
@@ -105,7 +105,7 @@ targets:
 type: ci-build
 underlay_from_ci_jobs:
 - nightly-extra-rmw-release
-keep_files:
+archive_files:
   - ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv
   - ws/test_results/buildfarm_perf_tests/overhead_test_results_*.csv
   - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv


### PR DESCRIPTION
Precisely what the title says. Depends on https://github.com/ros-infrastructure/ros_buildfarm/pull/784. Addresses https://github.com/ros2/buildfarm_perf_tests/issues/30.