### PR TITLE
Make the Fci job priority consistent

### DIFF
--- a/foxy/ci-nightly-performance.yaml
+++ b/foxy/ci-nightly-performance.yaml
@@ -25,7 +25,7 @@ install_packages:
 - ros-noetic-rospy-tutorials
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
-jenkins_job_priority: 48
+jenkins_job_priority: 47
 jenkins_job_timeout: 180
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release


### PR DESCRIPTION
The rest of the Foxy jobs got priority 47. This value didn't get changed when the config was copied from Eloquent.

Follow-up to #86.