### PR TITLE
Increase timeout for nightly Connext CI job

### DIFF
--- a/foxy/ci-nightly-connext.yaml
+++ b/foxy/ci-nightly-connext.yaml
@@ -23,7 +23,7 @@ install_packages:
 jenkins_job_label: ci-agent
 jenkins_job_priority: 47
 jenkins_job_schedule: 15 23 * * *
-jenkins_job_timeout: 300
+jenkins_job_timeout: 600
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*cyclonedds.* .*fastrtps.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos


### PR DESCRIPTION
Example job timing out: http://build.ros2.org/view/Fci/job/Fci__nightly-connext_ubuntu_focal_amd64/96

I think this is happening for Foxy because of the increase in ros2cli tests, which takes significantly more time to complete compared to past ROS distros.