### PR TITLE
Stop showing all of the performance plots

### DIFF
--- a/dashing/ci-nightly-performance.yaml
+++ b/dashing/ci-nightly-performance.yaml
@@ -105,12 +105,15 @@ targets:
 type: ci-build
 underlay_from_ci_jobs:
 - nightly-extra-rmw-release
-show_images:
-  Performance Test Results:
-  - ws/test_results/buildfarm_perf_tests/performance_test_results_*.png
-  - ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png
-  - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png
-  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png
+archive_files:
+- ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv
+- ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png
+- ws/test_results/buildfarm_perf_tests/overhead_test_results_*.csv
+- ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png
+- ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv
+- ws/test_results/buildfarm_perf_tests/performance_test_results_*.png
+- ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.csv
+- ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png
 show_plots:
   Node Spinnig Results:
   - title: Node Spinning Virtual Memory

--- a/eloquent/ci-nightly-performance.yaml
+++ b/eloquent/ci-nightly-performance.yaml
@@ -105,12 +105,15 @@ targets:
 type: ci-build
 underlay_from_ci_jobs:
 - nightly-extra-rmw-release
-show_images:
-  Performance Test Results:
-  - ws/test_results/buildfarm_perf_tests/performance_test_results_*.png
-  - ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png
-  - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png
-  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png
+archive_files:
+- ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv
+- ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png
+- ws/test_results/buildfarm_perf_tests/overhead_test_results_*.csv
+- ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png
+- ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv
+- ws/test_results/buildfarm_perf_tests/performance_test_results_*.png
+- ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.csv
+- ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png
 show_plots:
   Node Spinnig Results:
   - title: Node Spinning Virtual Memory

--- a/foxy/ci-nightly-performance.yaml
+++ b/foxy/ci-nightly-performance.yaml
@@ -106,16 +106,14 @@ type: ci-build
 underlay_from_ci_jobs:
 - nightly-extra-rmw-release
 archive_files:
-- ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv
-- ws/test_results/buildfarm_perf_tests/overhead_test_results_*.csv
 - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv
+- ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png
+- ws/test_results/buildfarm_perf_tests/overhead_test_results_*.csv
+- ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png
+- ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv
+- ws/test_results/buildfarm_perf_tests/performance_test_results_*.png
 - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.csv
-show_images:
-  Performance Test Results:
-  - ws/test_results/buildfarm_perf_tests/performance_test_results_*.png
-  - ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png
-  - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png
-  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png
+- ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png
 show_plots:
   Overhead simple publisher and subscriber - Average Round-Trip Time:
   - title: Simple Pub rmw_fastrtps_cpp_async Average Round-Trip Time


### PR DESCRIPTION
There are now over 1000 PNG plots being generated during the nightly performance jobs. This makes the build page WAY too big and take really long to load. Even after it does, finding the plot you're interested in is almost impossible given that there are no text titles to search for (the titles are embedded in the images).

I think we should just disable the image gallery plugin. We can keep the plots as archived file artifacts so that they can be linked to from the build-over-build plots.

Results in the following diff:
<details>

```
Updating job 'Dci__nightly-performance_ubuntu_bionic_amd64' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -503 +503 @@
    -      <artifacts>ros2-dashing-linux-bionic-amd64-ci.tar.bz2,ws/test_results/buildfarm_perf_tests/performance_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png,ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png</artifacts>
    +      <artifacts>ros2-dashing-linux-bionic-amd64-ci.tar.bz2,ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv,ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_test_results_*.csv,ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png,ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv,ws/test_results/buildfarm_perf_tests/performance_test_results_*.png,ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.csv,ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png</artifacts>
    @@ -510,10 +509,0 @@
    -    <org.jenkinsci.plugins.imagegallery.ImageGalleryRecorder plugin="image-gallery@1.4">
    -      <imageGalleries>
    -        <org.jenkinsci.plugins.imagegallery.imagegallery.ArchivedImagesGallery>
    -          <title>Performance Test Results</title>
    -          <imageWidthText />
    -          <markBuildAsUnstableIfNoArchivesFound>false</markBuildAsUnstableIfNoArchivesFound>
    -          <includes>ws/test_results/buildfarm_perf_tests/performance_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png,ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png</includes>
    -        </org.jenkinsci.plugins.imagegallery.imagegallery.ArchivedImagesGallery>
    -      </imageGalleries>
    -    </org.jenkinsci.plugins.imagegallery.ImageGalleryRecorder>
    >>>
Updating job 'Eci__nightly-performance_ubuntu_bionic_amd64' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -503 +503 @@
    -      <artifacts>ros2-eloquent-linux-bionic-amd64-ci.tar.bz2,ws/test_results/buildfarm_perf_tests/performance_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png,ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png</artifacts>
    +      <artifacts>ros2-eloquent-linux-bionic-amd64-ci.tar.bz2,ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv,ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_test_results_*.csv,ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png,ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv,ws/test_results/buildfarm_perf_tests/performance_test_results_*.png,ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.csv,ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png</artifacts>
    @@ -510,10 +509,0 @@
    -    <org.jenkinsci.plugins.imagegallery.ImageGalleryRecorder plugin="image-gallery@1.4">
    -      <imageGalleries>
    -        <org.jenkinsci.plugins.imagegallery.imagegallery.ArchivedImagesGallery>
    -          <title>Performance Test Results</title>
    -          <imageWidthText />
    -          <markBuildAsUnstableIfNoArchivesFound>false</markBuildAsUnstableIfNoArchivesFound>
    -          <includes>ws/test_results/buildfarm_perf_tests/performance_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png,ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png</includes>
    -        </org.jenkinsci.plugins.imagegallery.imagegallery.ArchivedImagesGallery>
    -      </imageGalleries>
    -    </org.jenkinsci.plugins.imagegallery.ImageGalleryRecorder>
    >>>
Updating job 'Fci__nightly-performance_ubuntu_focal_amd64' (dry run)
    <<<
    --- remote config
    +++ new config
    @@ -503 +503 @@
    -      <artifacts>ros2-foxy-linux-focal-amd64-ci.tar.bz2,ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv,ws/test_results/buildfarm_perf_tests/overhead_test_results_*.csv,ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv,ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.csv,ws/test_results/buildfarm_perf_tests/performance_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png,ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png</artifacts>
    +      <artifacts>ros2-foxy-linux-focal-amd64-ci.tar.bz2,ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv,ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_test_results_*.csv,ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png,ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv,ws/test_results/buildfarm_perf_tests/performance_test_results_*.png,ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.csv,ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png</artifacts>
    @@ -510,10 +509,0 @@
    -    <org.jenkinsci.plugins.imagegallery.ImageGalleryRecorder plugin="image-gallery@1.4">
    -      <imageGalleries>
    -        <org.jenkinsci.plugins.imagegallery.imagegallery.ArchivedImagesGallery>
    -          <title>Performance Test Results</title>
    -          <imageWidthText />
    -          <markBuildAsUnstableIfNoArchivesFound>false</markBuildAsUnstableIfNoArchivesFound>
    -          <includes>ws/test_results/buildfarm_perf_tests/performance_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png,ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png,ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png</includes>
    -        </org.jenkinsci.plugins.imagegallery.imagegallery.ArchivedImagesGallery>
    -      </imageGalleries>
    -    </org.jenkinsci.plugins.imagegallery.ImageGalleryRecorder>
    >>>
```

</details>