### PR TITLE
Specify search path to fastrtpsgen

### DIFF
--- a/dashing/ci-nightly-performance.yaml
+++ b/dashing/ci-nightly-performance.yaml
@@ -10,7 +10,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_PROGRAM_PATH=../../../bin --no-warn-unused-cli'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS

--- a/eloquent/ci-nightly-performance.yaml
+++ b/eloquent/ci-nightly-performance.yaml
@@ -10,7 +10,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_PROGRAM_PATH=../../../bin --no-warn-unused-cli'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS

--- a/foxy/ci-nightly-performance.yaml
+++ b/foxy/ci-nightly-performance.yaml
@@ -10,7 +10,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
-build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 -DCMAKE_PROGRAM_PATH=../../../bin --no-warn-unused-cli'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS


### PR DESCRIPTION
This should squelch a WARNING message coming out of [performance_test/src/idlgen/fast_rtps/CMakeLists.txt](https://github.com/ros2/performance_test/blob/ff3c693ac3b6df31bf95e7e17df9ac20b9c39726/performance_test/src/idlgen/fast_rtps/CMakeLists.txt#L67-L74).

Docs for `CMAKE_PROGRAM_PATH`: https://cmake.org/cmake/help/latest/variable/CMAKE_PROGRAM_PATH.html#variable:CMAKE_PROGRAM_PATH

I'm open to other suggestions for how to quiet the warning.