### PR TITLE
Increase Foxy package counts for sync

### DIFF
--- a/foxy/release-build.yaml
+++ b/foxy/release-build.yaml
@@ -16,7 +16,7 @@ notifications:
   - ros2-buildfarm-foxy@googlegroups.com
   maintainers: true
 sync:
-  package_count: 3
+  package_count: 262
 repositories:
   keys:
   - |

--- a/foxy/release-focal-arm64-build.yaml
+++ b/foxy/release-focal-arm64-build.yaml
@@ -13,7 +13,7 @@ notifications:
   - ros2-buildfarm-foxy@googlegroups.com
   maintainers: true
 sync:
-  package_count: 3
+  package_count: 262
 repositories:
   keys:
   - |


### PR DESCRIPTION
There are a total of 292 packages released, the new package count of 262 represents about 0.9 of the packages.
We are not changing the package count for armhf, since the jobs are currently failing.