### PR TITLE
Increase Foxy package counts for sync

### DIFF
--- a/foxy/release-build.yaml
+++ b/foxy/release-build.yaml
@@ -16,7 +16,7 @@ notifications:
   - ros2-buildfarm-foxy@googlegroups.com
   maintainers: true
 sync:
-  package_count: 262
+  package_count: 381
 repositories:
   keys:
   - |

--- a/foxy/release-focal-arm64-build.yaml
+++ b/foxy/release-focal-arm64-build.yaml
@@ -13,7 +13,7 @@ notifications:
   - ros2-buildfarm-foxy@googlegroups.com
   maintainers: true
 sync:
-  package_count: 262
+  package_count: 381
 repositories:
   keys:
   - |


### PR DESCRIPTION
381 represents 0.9 of the 424 packages released.