### PR TITLE
set NDDSHOME env var for dev/PR jobs

### DIFF
--- a/dashing/source-build.yaml
+++ b/dashing/source-build.yaml
@@ -2,6 +2,7 @@
 # ROS buildfarm source-build file
 ---
 build_environment_variables:
+  NDDSHOME: /opt/rti.com/rti_connext_dds-5.3.1
   ROS_PYTHON_VERSION: 3
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon

--- a/eloquent/source-build.yaml
+++ b/eloquent/source-build.yaml
@@ -2,6 +2,7 @@
 # ROS buildfarm source-build file
 ---
 build_environment_variables:
+  NDDSHOME: /opt/rti.com/rti_connext_dds-5.3.1
   ROS_PYTHON_VERSION: 3
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon

--- a/foxy/source-build.yaml
+++ b/foxy/source-build.yaml
@@ -2,6 +2,7 @@
 # ROS buildfarm source-build file
 ---
 build_environment_variables:
+  NDDSHOME: /opt/rti.com/rti_connext_dds-5.3.1
   ROS_PYTHON_VERSION: 3
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon

--- a/rolling/source-build.yaml
+++ b/rolling/source-build.yaml
@@ -2,6 +2,7 @@
 # ROS buildfarm source-build file
 ---
 build_environment_variables:
+  NDDSHOME: /opt/rti.com/rti_connext_dds-5.3.1
   ROS_PYTHON_VERSION: 3
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon


### PR DESCRIPTION
Fixes the `rosidl_typesupport_connext` dev/PR jobs which are otherwise not able to find Connext. Example build with this change: http://build.ros2.org/view/Rdev/job/Rdev__rosidl_typesupport_connext__ubuntu_focal_amd64/3/