### PR TITLE
Install libssl-dev for connext-cyclonedds cross vendor test

### DIFF
--- a/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -12,9 +12,9 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk # for CycloneDDS
+- libssl-dev  # for Connext and CycloneDDS
 - libtinyxml2-dev # for FastRTPS, even though disabled it is needed for the typesupport
 - maven # for CycloneDDS
-- libssl-dev  # for Connext and CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_timeout: 300

--- a/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -14,6 +14,7 @@ install_packages:
 - default-jdk # for CycloneDDS
 - libtinyxml2-dev # for FastRTPS, even though disabled it is needed for the typesupport
 - maven # for CycloneDDS
+- libssl-dev  # for Connext and CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -15,6 +15,7 @@ install_packages:
 - default-jdk # for CycloneDDS
 - libtinyxml2-dev # for FastRTPS, even though disabled it is needed for the typesupport
 - maven # for CycloneDDS
+- libssl-dev  # for Connext and CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -13,9 +13,9 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TEST
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - default-jdk # for CycloneDDS
+- libssl-dev  # for Connext and CycloneDDS
 - libtinyxml2-dev # for FastRTPS, even though disabled it is needed for the typesupport
 - maven # for CycloneDDS
-- libssl-dev  # for Connext and CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300


### PR DESCRIPTION
I think this should resolve these builds that are failing to find OpenSSL:

http://build.ros2.org/view/Rci/job/Rci__nightly-cross-vendor-connext-cyclonedds_ubuntu_focal_amd64/23
http://build.ros2.org/view/Fci/job/Fci__nightly-cross-vendor-connext-cyclonedds_ubuntu_focal_amd64/115/

It looks like libssl-dev is being installed transitively in other jobs either by libasio-dev (a Fast-DDS dependency) or ROS 1.