### PR TITLE
Exclude 'performance' test label in rolling jobs

### DIFF
--- a/rolling/ci-nightly-connext.yaml
+++ b/rolling/ci-nightly-connext.yaml
@@ -11,7 +11,7 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - ros-noetic-common-msgs
 - ros-noetic-rosbash

--- a/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -10,7 +10,7 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - default-jdk # for CycloneDDS
 - libssl-dev  # for Connext and CycloneDDS

--- a/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -10,7 +10,7 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS

--- a/rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -8,7 +8,7 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS

--- a/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -9,7 +9,7 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'  # even thought not used installed for the underlay
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS

--- a/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -7,7 +7,7 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'  # even thought not used installed for the underlay
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS

--- a/rolling/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -7,7 +7,7 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'  # even thought not used installed for the underlay
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS

--- a/rolling/ci-nightly-cyclonedds.yaml
+++ b/rolling/ci-nightly-cyclonedds.yaml
@@ -9,7 +9,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: '3'
 build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - default-jdk # for CycloneDDS
 - maven # for CycloneDDS

--- a/rolling/ci-nightly-debug.yaml
+++ b/rolling/ci-nightly-debug.yaml
@@ -11,7 +11,7 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS

--- a/rolling/ci-nightly-extra-rmw-release.yaml
+++ b/rolling/ci-nightly-extra-rmw-release.yaml
@@ -11,7 +11,7 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS

--- a/rolling/ci-nightly-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-fastrtps-dynamic.yaml
@@ -9,7 +9,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: '3'
 build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS

--- a/rolling/ci-nightly-fastrtps.yaml
+++ b/rolling/ci-nightly-fastrtps.yaml
@@ -9,7 +9,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: '3'
 build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - libasio-dev # for FastRTPS
 - libtinyxml2-dev # for FastRTPS

--- a/rolling/ci-nightly-release.yaml
+++ b/rolling/ci-nightly-release.yaml
@@ -11,7 +11,7 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS

--- a/rolling/ci-overlay.yaml
+++ b/rolling/ci-overlay.yaml
@@ -10,7 +10,7 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
-build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE performance -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS

--- a/rolling/source-build.yaml
+++ b/rolling/source-build.yaml
@@ -6,6 +6,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: 3
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
+build_tool_test_args: '--ctest-args -LE performance'
 jenkins_commit_job_priority: 50
 jenkins_job_timeout: 120
 jenkins_pull_request_job_priority: 40


### PR DESCRIPTION
We don't want to run the performance tests except under specific circumstances. This change excludes them by default from all of the CI and source-based jobs.

This doesn't handle the release jobs at all. Without making the tests disabled by default, I don't see a way to make this happen without changes in Bloom.

Previous discussion was here: https://github.com/ament/ament_cmake/pull/261#discussion_r455406311
Discussion during the ROS 2 planning meeting wasn't fruitful either.