### PR TITLE
Add Rolling CI job for Performance Testing

### DIFF
--- a/common/benchmark_schema.yaml
+++ b/common/benchmark_schema.yaml
@@ -1,0 +1,140 @@
+# This JSON schema was taken from:
+# https://github.com/ament/ament_cmake/blob/master/ament_cmake_google_benchmark/doc/benchmark_schema.json
+|
+  {
+    "description": "Jenkins Benchmark schema for ROS performance test results",
+    "failure": {
+      "value": true
+    },
+    "type": "object",
+    "additionalProperties": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "description"
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "parameter",
+            "properties": {
+              "description": {
+                "type": "description"
+              },
+              "unit": {
+                "type": "unit"
+              },
+              "value": {
+                "type": "value"
+              }
+            },
+            "required": [
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "description"
+          },
+          "parameters": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "parameter",
+              "properties": {
+                "description": {
+                  "type": "description"
+                },
+                "unit": {
+                  "type": "unit"
+                },
+                "value": {
+                  "type": "value"
+                }
+              },
+              "required": [
+                "value"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": {
+          "type": "result",
+          "properties": {
+            "description": {
+              "type": "description"
+            },
+            "parameters": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "parameter",
+                "properties": {
+                  "description": {
+                    "type": "description"
+                  },
+                  "unit": {
+                    "type": "unit"
+                  },
+                  "value": {
+                    "type": "value"
+                  }
+                },
+                "required": [
+                  "value"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "boolValue": {
+              "type": "boolean"
+            },
+            "dblValue": {
+              "type": "double"
+            },
+            "intValue": {
+              "type": "integer"
+            },
+            "unit": {
+              "type": "unit"
+            },
+            "value": {
+              "type": "value"
+            },
+            "thresholds": {
+              "type": "array",
+              "items": {
+                "type": "threshold",
+                "properties": {
+                  "delta": {
+                    "type": "delta"
+                  },
+                  "method": {
+                    "type": "method"
+                  },
+                  "maximum": {
+                    "type": "maximum"
+                  },
+                  "minimum": {
+                    "type": "minimum"
+                  },
+                  "percentage": {
+                    "type": "percentage"
+                  }
+                },
+                "required": [
+                  "method"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      }
+    }
+  }

--- a/index.yaml
+++ b/index.yaml
@@ -77,6 +77,7 @@ distributions:
       default: foxy/source-build.yaml
   rolling:
     ci_builds:
+      benchmark: rolling/ci-benchmark.yaml
       nightly-connext: rolling/ci-nightly-connext.yaml
       nightly-cross-vendor-connext-cyclonedds: rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
       nightly-cross-vendor-connext-fastrtps: rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml

--- a/rolling/ci-benchmark.yaml
+++ b/rolling/ci-benchmark.yaml
@@ -1,0 +1,122 @@
+%YAML 1.1
+# ROS buildfarm ci-build file
+---
+build_environment_variables:
+  CMAKE_PREFIX_PATH: '/opt/ros/noetic:$CMAKE_PREFIX_PATH'
+  LD_LIBRARY_PATH: '/opt/ros/noetic/lib:$LD_LIBRARY_PATH'
+  NDDSHOME: '/opt/rti.com/rti_connext_dds-5.3.1'
+  PYTHONPATH: '/opt/ros/noetic/lib/python3/dist-packages:$PYTHONPATH'
+  ROS_PYTHON_VERSION: '3'
+  RTI_NC_LICENSE_ACCEPTED: 'yes'
+benchmark_patterns:
+- ws/test_results/**/*.benchmark.json
+benchmark_schema: !include ../common/benchmark_schema.yaml
+build_tool: colcon
+build_tool_args: '--cmake-args -DAMENT_RUN_PERFORMANCE_TESTS=ON -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
+build_tool_test_args: '--ctest-args -L performance --pytest-args -m "performance"'
+install_packages:
+- default-jdk # for CycloneDDS
+- libasio-dev # for FastRTPS
+- libtinyxml2-dev # for FastRTPS
+- maven # for CycloneDDS
+- ros-noetic-common-msgs
+- ros-noetic-rosbash
+- ros-noetic-roscpp
+- ros-noetic-roscpp-tutorials
+- ros-noetic-roslaunch
+- ros-noetic-rosmsg
+- ros-noetic-rospy-tutorials
+- ros-noetic-tf2-msgs
+jenkins_job_label: ci-agent
+jenkins_job_priority: 50
+jenkins_job_timeout: 240
+package_selection_args: >
+  --packages-select
+  libstatistics_collector
+  rcl_logging_spdlog
+  rcl_yaml_param_parser
+  rmw_dds_common
+  rmw_implementation
+  rosidl_runtime_c
+  rosidl_runtime_cpp
+  rosidl_typesupport_c
+  rosidl_typesupport_cpp
+  rosidl_typesupport_fastrtps_c
+  rosidl_typesupport_fastrtps_cpp
+repos_files:
+- https://github.com/ros2/ros2/raw/master/ros2.repos
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQoA
+    PhYhBMHPbjHmut6IaLFytPQu1vurF8ZUBQJc7yaWAhsDBQkDwmcABQsJCAcCBhUK
+    CQgLAgQWAgMBAh4BAheAAAoJEPQu1vurF8ZUkhIP/RbZY1ErvCEUy8iLJm9aSpLQ
+    nDZl5xILOxyZlzpg+Ml5bb0EkQDr92foCgcvLeANKARNCaGLyNIWkuyDovPV0xZJ
+    rEy0kgBrDNb3++NmdI/+GA92pkedMXXioQvqdsxUagXAIB/sNGByJEhs37F05AnF
+    vZbjUhceq3xTlvAMcrBWrgB4NwBivZY6IgLvl/CRQpVYwANShIQdbvHvZSxRonWh
+    NXr6v/Wcf8rsp7g2VqJ2N2AcWT84aa9BLQ3Oe/SgrNx4QEhA1y7rc3oaqPVu5ZXO
+    K+4O14JrpbEZ3Xs9YEjrcOuEDEpYktA8qqUDTdFyZrxb9S6BquUKrA6jZgT913kj
+    J4e7YAZobC4rH0w4u0PrqDgYOkXA9Mo7L601/7ZaDJob80UcK+Z12ZSw73IgBix6
+    DiJVfXuWkk5PM2zsFn6UOQXUNlZlDAOj5NC01V0fJ8P0v6GO9YOSSQx0j5UtkUbR
+    fp/4W7uCPFvwAatWEHJhlM3sQNiMNStJFegr56xQu1a/cbJH7GdbseMhG/f0BaKQ
+    qXCI3ffB5y5AOLc9Hw7PYiTFQsuY1ePRhE+J9mejgWRZxkjAH/FlAubqXkDgterC
+    h+sLkzGf+my2IbsMCuc+3aeNMJ5Ej/vlXefCH/MpPWAHCqpQhe2DET/jRSaM53US
+    AHNx8kw4MPUkxExgI7Sd
+    =4Ofr
+    -----END PGP PUBLIC KEY BLOCK-----
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.11 (GNU/Linux)
+
+    mQGiBEsy5KkRBADJbDSISoamRM5AA20bfAeBuhhaI+VaiCVcxw90sq9AI5lIc42F
+    WzM2acm8yplqWiehAqOLKd+iIrqNGZ+VavZEPTx7o06UZUMRoPBiTFaCwrQ5avKz
+    lt7ij8PRMVWNrJ7A2lDYXfFQVV1o3Xo06qVnv0KLLUmiur0LBu4H/oTH3wCgt+/I
+    D3LUKaMJsc77KwFBTjHB0EsD/26Z2Ud12f3urSNyN6VMWnP3rz6xsmtY4Qsmkbnr
+    JuduxCQBZv6bX1Cr2ulXkv0fFOr+s5OyUv7zyCPbxiJFh3Br7fJGb0b5/M208KPe
+    giITY9hMh/aUbKjXCPoOXPxSL6SWOWV8taR6903EFyLBN0qno/kXIBKnVqBZobgn
+    jIEPA/0fTnxtZtE7EpirGQMF2caJfv7/LCgXmRs9xAhgbE0/caoa1tnc79uaHmLZ
+    FtbGFoAO31YNYM/IUHtmabbGdvZ4oYUwDhjBevVvC7aI+XhuNGK5mU8qCLLSEUOl
+    CUr6BJq/0iFmjwjmwk9idZEYhqSNy2OoYJbq45rbHfbdKLEVrbQeUk9TIEJ1aWxk
+    ZXIgPHJvc2J1aWxkQHJvcy5vcmc+iGAEExECACAFAksy5KkCGwMGCwkIBwMCBBUC
+    CAMEFgIDAQIeAQIXgAAKCRBVI7rusB+hFmk7AJ0XsLp05KA8l3YzAumZfjSN04MZ
+    jQCfQHfp4aQUXdOCUtetVo0QZUX3IuO5Ag0ESzLkrhAIAOCuSC83VXYWf8gOMSzd
+    xwpsH/uLV9Wze2LGnajsJLjEOhcsz2BHfxqNXhYaE9aQaodPCpbUAkPq8tLbpXy0
+    SWRCx0F5RcplXx5vIWbP6TlfPbRpK70w7IWd6vsNrjwEHjlhOLcNcj42sp5pgx4b
+    dceK06k5Ml2hYovPnD9o2TYgjOqg5FHZ2g1J0103n/66bN/hZnpLaZJYQiPWCyq6
+    K0565i1k2Y7hgWB/OXqwaqCehqmLTvpyQGzE1UJvKLuYU+T+4hBnSPbT3KIi5fCz
+    lIwvxijOMcfbkLhzYQXcU0Rd1VItcd5nmPL4z97jBxzuhkgxXpGR4WGKhvsA2Z9Y
+    UtsAAwYH/3Bf44bTpD9bVADUdab3e7zm8iHfh9K/a83mIgDB7mHV6WuemQVTf/1d
+    eu4mI5WtpbOCoucybGfjGIIAcSxwIx6VfC7HSp4J51bOpHhbdDffUEk6QVsZjwoF
+    yn3W9W3ZVeTI+ch/Qoo5a98SnmdjN8eXI/qCuiXOHc6rXDXc2R0iox/1EAS8xGVd
+    cYZe7IWBO2CjCknyhLrWxZHoy+i1GCZ9KvPF/Ef2dmLhCydT73ZlumsY8N5vm76Q
+    ul1G7f8LNbnMgXQafRkPffrAXSVhGY3Z2IiBwFNgxcKTq479l7yedYRGeU1A+SYI
+    YmRFWHXt3rTkMlQSpxCsB0fAYfrwEqqISQQYEQIACQUCSzLkrgIbDAAKCRBVI7ru
+    sB+hFpryAJ4puo6cMZxa6wITHFAM/k84+aRijwCeItuWpUngP25xDuDGMsKarcNi
+    qYE=
+    =Vgio
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repo.ros2.org/ubuntu/testing
+  - http://repositories.ros.org/ubuntu/testing
+targets:
+  ubuntu:
+    focal:
+      amd64:
+type: ci-build
+underlay_from_ci_jobs:
+- nightly-extra-rmw-release
+version: 1

--- a/rolling/ci-benchmark.yaml
+++ b/rolling/ci-benchmark.yaml
@@ -13,7 +13,7 @@ benchmark_patterns:
 benchmark_schema: !include ../common/benchmark_schema.yaml
 build_tool: colcon
 build_tool_args: '--cmake-args -DAMENT_RUN_PERFORMANCE_TESTS=ON -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
-build_tool_test_args: '--ctest-args -L performance --pytest-args -m "performance"'
+build_tool_test_args: '--ctest-args -L performance --pytest-args -m performance'
 install_packages:
 - default-jdk # for CycloneDDS
 - libasio-dev # for FastRTPS


### PR DESCRIPTION
This job will target specific packages for now, but eventually, when performance testing is widespread, we may remove the `--packages-select` list and just build everything. For now, since there are so few packages that we're even targeting with performance tests, it makes sense to only build the ones we'll actually be testing.