### PR TITLE
Drop the explicit list of packages with benchmarks

### DIFF
--- a/rolling/ci-benchmark.yaml
+++ b/rolling/ci-benchmark.yaml
@@ -31,24 +31,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 30 23 * * *
 jenkins_job_timeout: 240
-package_selection_args: >
-  --packages-select
-  ament_cmake_google_benchmark
-  console_bridge_vendor
-  google_benchmark_vendor
-  libstatistics_collector
-  osrf_testing_tools_cpp
-  performance_test_fixture
-  rcl_logging_spdlog
-  rcl_yaml_param_parser
-  rmw_dds_common
-  rmw_implementation
-  rosidl_runtime_c
-  rosidl_runtime_cpp
-  rosidl_typesupport_c
-  rosidl_typesupport_cpp
-  rosidl_typesupport_fastrtps_c
-  rosidl_typesupport_fastrtps_cpp
+package_selection_args: '--packages-above-depth 1 google_benchmark_vendor ament_cmake_google_benchmark performance_test_fixture'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:


### PR DESCRIPTION
It occurred to me that each package that is currently building benchmarks takes a dependency on at least one of these packages, so we can use that to build exactly what we need every time, even when new packages and new benchmarks come online.

My test build showed that all of the packages explicitly listed here were picked up as expected. Additionally, it looks like @sloretz added some benchmarks to `urdf` that I didn't know about, and they were picked up and run by this job automatically, which is a great demonstration of the value of this change :)