### PR TITLE
create separate image galleries for each group / subgroup of performance plots

### DIFF
--- a/rolling/ci-nightly-performance.yaml
+++ b/rolling/ci-nightly-performance.yaml
@@ -111,14 +111,82 @@ archive_files:
 - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.csv
 - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.csv
 show_images:
-  Performance Test Results:
-  - ws/test_results/buildfarm_perf_tests/performance_test_results_*.png
-  Overhead Test Results:
-  - ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png
-  Overhead Node Test Results:
-  - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png
-  Performance Test Two Process Results:
-  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png
+  Performance Test Results - FastRTPS async:
+  - ws/test_results/buildfarm_perf_tests/performance_test_results_FastRTPS_async_*.png
+  Performance Test Results - FastRTPS sync:
+  - ws/test_results/buildfarm_perf_tests/performance_test_results_FastRTPS_sync_*.png
+  Performance Test Results - rmw_connext_cpp async:
+  - ws/test_results/buildfarm_perf_tests/performance_test_results_rmw_connext_cpp_async_*.png
+  Performance Test Results - rmw_cyclonedds_cpp sync:
+  - ws/test_results/buildfarm_perf_tests/performance_test_results_rmw_cyclonedds_cpp_sync_*.png
+  Performance Test Results - rmw_fastrtps_cpp async:
+  - ws/test_results/buildfarm_perf_tests/performance_test_results_rmw_fastrtps_cpp_async_*.png
+  Performance Test Results - rmw_fastrtps_cpp sync:
+  - ws/test_results/buildfarm_perf_tests/performance_test_results_rmw_fastrtps_cpp_sync_*.png
+  Performance Test Results - rmw_fastrtps_dynamic_cpp async:
+  - ws/test_results/buildfarm_perf_tests/performance_test_results_rmw_fastrtps_dynamic_cpp_async_*.png
+  Performance Test Results - rmw_fastrtps_dynamic_cpp sync:
+  - ws/test_results/buildfarm_perf_tests/performance_test_results_rmw_fastrtps_dynamic_cpp_sync_*.png
+  Overhead Test Results - rmw_connext_cpp - rmw_connext_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_connext_cpp_Subscriber-rmw_connext_cpp_*.png
+  Overhead Test Results - rmw_connext_cpp - rmw_cyclonedds_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_connext_cpp_Subscriber-rmw_cyclonedds_cpp_*.png
+  Overhead Test Results - rmw_connext_cpp - rmw_fastrtps_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_connext_cpp_Subscriber-rmw_fastrtps_cpp_*.png
+  Overhead Test Results - rmw_connext_cpp - rmw_fastrtps_dynamic_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_connext_cpp_Subscriber-rmw_fastrtps_dynamic_cpp_*.png
+  Overhead Test Results - rmw_cyclonedds_cpp - rmw_connext_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_cyclonedds_cpp_Subscriber-rmw_connext_cpp_*.png
+  Overhead Test Results - rmw_cyclonedds_cpp - rmw_cyclonedds_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_cyclonedds_cpp_Subscriber-rmw_cyclonedds_cpp_*.png
+  Overhead Test Results - rmw_cyclonedds_cpp - rmw_fastrtps_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_cyclonedds_cpp_Subscriber-rmw_fastrtps_cpp_*.png
+  Overhead Test Results - rmw_cyclonedds_cpp - rmw_fastrtps_dynamic_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_cyclonedds_cpp_Subscriber-rmw_fastrtps_dynamic_cpp_*.png
+  Overhead Test Results - rmw_fastrtps_cpp - rmw_connext_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_fastrtps_cpp_Subscriber-rmw_connext_cpp_*.png
+  Overhead Test Results - rmw_fastrtps_cpp - rmw_cyclonedds_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_fastrtps_cpp_Subscriber-rmw_cyclonedds_cpp_*.png
+  Overhead Test Results - rmw_fastrtps_cpp - rmw_fastrtps_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_fastrtps_cpp_Subscriber-rmw_fastrtps_cpp_*.png
+  Overhead Test Results - rmw_fastrtps_cpp - rmw_fastrtps_dynamic_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_fastrtps_cpp_Subscriber-rmw_fastrtps_dynamic_cpp_*.png
+  Overhead Test Results - rmw_fastrtps_dynamic_cpp - rmw_connext_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_fastrtps_dynamic_cpp_Subscriber-rmw_connext_cpp_*.png
+  Overhead Test Results - rmw_fastrtps_dynamic_cpp - rmw_cyclonedds_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_fastrtps_dynamic_cpp_Subscriber-rmw_cyclonedds_cpp_*.png
+  Overhead Test Results - rmw_fastrtps_dynamic_cpp - rmw_fastrtps_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_fastrtps_dynamic_cpp_Subscriber-rmw_fastrtps_cpp_*.png
+  Overhead Test Results - rmw_fastrtps_dynamic_cpp - rmw_fastrtps_dynamic_cpp:
+  - ws/test_results/buildfarm_perf_tests/overhead_test_results_Publisher-rmw_fastrtps_dynamic_cpp_Subscriber-rmw_fastrtps_dynamic_cpp_*.png
+  Overhead Node Test Results - rmw_connext_cpp async:
+  - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_rmw_connext_cpp_async_*.png
+  Overhead Node Test Results - rmw_cyclonedds_cpp sync:
+  - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_rmw_cyclonedds_cpp_sync_*.png
+  Overhead Node Test Results - rmw_fastrtps_cpp async:
+  - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_rmw_fastrtps_cpp_async_*.png
+  Overhead Node Test Results - rmw_fastrtps_cpp sync:
+  - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_rmw_fastrtps_cpp_sync_*.png
+  Overhead Node Test Results - rmw_fastrtps_dynamic_cpp async:
+  - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_rmw_fastrtps_dynamic_cpp_async_*.png
+  Overhead Node Test Results - rmw_fastrtps_dynamic_cpp sync:
+  - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_rmw_fastrtps_dynamic_cpp_sync_*.png
+  Performance Test Two Process Results - FastRTPS async:
+  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_FastRTPS_async_*.png
+  Performance Test Two Process Results - FastRTPS sync:
+  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_FastRTPS_sync_*.png
+  Performance Test Two Process Results - rmw_connext_cpp async:
+  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_rmw_connext_cpp_async_*.png
+  Performance Test Two Process Results - rmw_cyclonedds_cpp sync:
+  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_rmw_cyclonedds_cpp_sync_*.png
+  Performance Test Two Process Results - rmw_fastrtps_cpp async:
+  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_rmw_fastrtps_cpp_async_*.png
+  Performance Test Two Process Results - rmw_fastrtps_cpp sync:
+  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_rmw_fastrtps_cpp_sync_*.png
+  Performance Test Two Process Results - rmw_fastrtps_dynamic_cpp async:
+  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_rmw_fastrtps_dynamic_cpp_async_*.png
+  Performance Test Two Process Results - rmw_fastrtps_dynamic_cpp sync:
+  - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_rmw_fastrtps_dynamic_cpp_sync_*.png
 show_plots:
   Overhead simple publisher and subscriber - Average Round-Trip Time:
   - title: Simple Pub rmw_fastrtps_cpp_async Average Round-Trip Time

--- a/rolling/ci-nightly-performance.yaml
+++ b/rolling/ci-nightly-performance.yaml
@@ -113,8 +113,11 @@ archive_files:
 show_images:
   Performance Test Results:
   - ws/test_results/buildfarm_perf_tests/performance_test_results_*.png
+  Overhead Test Results:
   - ws/test_results/buildfarm_perf_tests/overhead_test_results_*.png
+  Overhead Node Test Results:
   - ws/test_results/buildfarm_perf_tests/overhead_node_test_results_*.png
+  Performance Test Two Process Results:
   - ws/test_results/buildfarm_perf_tests/performance_test_two_process_results_*.png
 show_plots:
   Overhead simple publisher and subscriber - Average Round-Trip Time:


### PR DESCRIPTION
Fixes ros2/buildfarm_perf_tests#85.