### PR TITLE
Fix list_priorities.py for configs which use !include tags.

### DIFF
--- a/list_priorities.py
+++ b/list_priorities.py
@@ -17,7 +17,7 @@ def get_priorities():
     base_path = os.path.dirname(__file__)
     for root, dirs, files in os.walk(base_path):
         # ignore folder starting with a dot
-        dirs[:] = [d for d in dirs if not d.startswith('.')]
+        dirs[:] = [d for d in dirs if not d.startswith('.') and d != 'common']
         dirs.sort()
 
         # ignore folder starting with a dot

--- a/list_priorities.py
+++ b/list_priorities.py
@@ -4,6 +4,21 @@ import os
 import yaml
 
 
+# Benchmark scripts use the include directive which is not required
+# for this script to run, so let's stub it out.
+class StubInclude():
+    def __init__(self, path):
+        self.path = path
+
+
+def include_constructor(loader, node, Loader=yaml.SafeLoader):
+    path = loader.construct_scalar(node)
+    return StubInclude(path)
+
+
+yaml.add_constructor(u'!include', include_constructor, Loader=yaml.SafeLoader)
+
+
 def main():
     priorities = get_priorities()
     for key in sorted(priorities.keys()):
@@ -16,7 +31,8 @@ def get_priorities():
     priorities = {}
     base_path = os.path.dirname(__file__)
     for root, dirs, files in os.walk(base_path):
-        # ignore folder starting with a dot
+        # ignore folder starting with a dot and the `common` directory
+        # which is used for !include tag sources.
         dirs[:] = [d for d in dirs if not d.startswith('.') and d != 'common']
         dirs.sort()
 
@@ -33,7 +49,7 @@ def get_priorities():
 
 def collect_priorities(path, relpath, priorities):
     with open(path, 'r') as h:
-        data = yaml.load(h)
+        data = yaml.load(h, Loader=yaml.SafeLoader)
     for key in sorted(data.keys()):
         if not key.endswith('_priority'):
             continue


### PR DESCRIPTION
This file, introduced in #120, causes the script to fail since it
contains a YAML string scalar rather than dict.

Even after this commit the script fails due to the include block in
rolling/ci-benchmark.yaml so that needs to be dealt with for this PR to
move forward. The easiest way would be to find a way to ignore the include since currently the priority field is not behind an include.

A cherry on top of this PR would be adding a GitHub Action which runs priority list on PRs which would also keep the script working.

FYI @cottsay