### PR TITLE
Enable the Jenkins Benchmark plugin in performance jobs

### DIFF
--- a/eloquent/ci-nightly-performance.yaml
+++ b/eloquent/ci-nightly-performance.yaml
@@ -9,6 +9,9 @@ build_environment_variables:
   ROS_PACKAGE_PATH: '/opt/ros/melodic/share'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
+benchmark_patterns:
+- ws/test_results/**/*.benchmark.json
+benchmark_schema: !include ../common/benchmark_schema.yaml
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DPERFORMANCE_TEST_CYCLONEDDS_ENABLED=1 -DPERFORMANCE_TEST_FASTRTPS_ENABLED=1 --no-warn-unused-cli'
 install_packages:

--- a/foxy/ci-nightly-performance.yaml
+++ b/foxy/ci-nightly-performance.yaml
@@ -9,6 +9,9 @@ build_environment_variables:
   ROS_PACKAGE_PATH: '/opt/ros/noetic/share'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
+benchmark_patterns:
+- ws/test_results/**/*.benchmark.json
+benchmark_schema: !include ../common/benchmark_schema.yaml
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 -DPERFORMANCE_TEST_CYCLONEDDS_ENABLED=1 -DPERFORMANCE_TEST_FASTRTPS_ENABLED=1 --no-warn-unused-cli'
 install_packages:

--- a/rolling/ci-nightly-performance.yaml
+++ b/rolling/ci-nightly-performance.yaml
@@ -9,6 +9,9 @@ build_environment_variables:
   ROS_PACKAGE_PATH: '/opt/ros/noetic/share'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
+benchmark_patterns:
+- ws/test_results/**/*.benchmark.json
+benchmark_schema: !include ../common/benchmark_schema.yaml
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 -DPERFORMANCE_TEST_CYCLONEDDS_ENABLED=1 -DPERFORMANCE_TEST_FASTRTPS_ENABLED=1 --no-warn-unused-cli'
 install_packages:


### PR DESCRIPTION
Connects to ros2/buildfarm_perf_tests#88

We can't merge this until I've deployed an updated version of the plugin to build.ros2.org to work around a bug.