### PR TITLE
Add job weight of 4 to CI jobs.

### DIFF
--- a/dashing/ci-nightly-connext.yaml
+++ b/dashing/ci-nightly-connext.yaml
@@ -24,6 +24,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 59
 jenkins_job_schedule: 15 23 2-29/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*cyclonedds.* .*fastrtps.* .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/dashing/ros2.repos

--- a/dashing/ci-nightly-cyclonedds.yaml
+++ b/dashing/ci-nightly-cyclonedds.yaml
@@ -24,6 +24,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 59
 jenkins_job_schedule: 15 23 2-29/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*fastrtps.* .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/dashing/ros2.repos

--- a/dashing/ci-nightly-debug.yaml
+++ b/dashing/ci-nightly-debug.yaml
@@ -26,6 +26,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 59
 jenkins_job_schedule: 15 23 2-29/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*cyclonedds.* .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/dashing/ros2.repos

--- a/dashing/ci-nightly-extra-rmw-release.yaml
+++ b/dashing/ci-nightly-extra-rmw-release.yaml
@@ -28,6 +28,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 59
 jenkins_job_schedule: 15 23 2-29/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/ros2/raw/dashing/ros2.repos
 repositories:

--- a/dashing/ci-nightly-fastrtps-dynamic.yaml
+++ b/dashing/ci-nightly-fastrtps-dynamic.yaml
@@ -24,6 +24,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 59
 jenkins_job_schedule: 15 23 2-29/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.* .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/dashing/ros2.repos

--- a/dashing/ci-nightly-fastrtps.yaml
+++ b/dashing/ci-nightly-fastrtps.yaml
@@ -24,6 +24,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 59
 jenkins_job_schedule: 15 23 2-29/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.* .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/dashing/ros2.repos

--- a/dashing/ci-nightly-opensplice.yaml
+++ b/dashing/ci-nightly-opensplice.yaml
@@ -22,6 +22,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 59
 jenkins_job_schedule: 15 23 2-29/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.* .*fastrtps.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/dashing/ros2.repos

--- a/dashing/ci-nightly-performance.yaml
+++ b/dashing/ci-nightly-performance.yaml
@@ -27,6 +27,7 @@ install_packages:
 jenkins_job_label: ci-agent
 jenkins_job_priority: 59
 jenkins_job_timeout: 180
+jenkins_job_weight: 4
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
 repos_files:

--- a/dashing/ci-nightly-release.yaml
+++ b/dashing/ci-nightly-release.yaml
@@ -26,6 +26,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 59
 jenkins_job_schedule: 15 23 2-29/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*cyclonedds.* .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/dashing/ros2.repos

--- a/dashing/ci-overlay.yaml
+++ b/dashing/ci-overlay.yaml
@@ -26,6 +26,7 @@ install_packages:
 jenkins_job_label: ci-agent
 jenkins_job_priority: 59
 jenkins_job_timeout: 240
+jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/ros2/raw/dashing/ros2.repos
 repositories:

--- a/eloquent/ci-nightly-connext.yaml
+++ b/eloquent/ci-nightly-connext.yaml
@@ -24,6 +24,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 58
 jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*cyclonedds.* .*fastrtps.* .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/eloquent/ros2.repos

--- a/eloquent/ci-nightly-cyclonedds.yaml
+++ b/eloquent/ci-nightly-cyclonedds.yaml
@@ -24,6 +24,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 58
 jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*fastrtps.* .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/eloquent/ros2.repos

--- a/eloquent/ci-nightly-debug.yaml
+++ b/eloquent/ci-nightly-debug.yaml
@@ -26,6 +26,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 58
 jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*cyclonedds.* .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/eloquent/ros2.repos

--- a/eloquent/ci-nightly-extra-rmw-release.yaml
+++ b/eloquent/ci-nightly-extra-rmw-release.yaml
@@ -28,6 +28,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 58
 jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/ros2/raw/eloquent/ros2.repos
 repositories:

--- a/eloquent/ci-nightly-fastrtps-dynamic.yaml
+++ b/eloquent/ci-nightly-fastrtps-dynamic.yaml
@@ -24,6 +24,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 58
 jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.* .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/eloquent/ros2.repos

--- a/eloquent/ci-nightly-fastrtps.yaml
+++ b/eloquent/ci-nightly-fastrtps.yaml
@@ -24,6 +24,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 58
 jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.* .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/eloquent/ros2.repos

--- a/eloquent/ci-nightly-opensplice.yaml
+++ b/eloquent/ci-nightly-opensplice.yaml
@@ -22,6 +22,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 58
 jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.* .*fastrtps.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/eloquent/ros2.repos

--- a/eloquent/ci-nightly-performance.yaml
+++ b/eloquent/ci-nightly-performance.yaml
@@ -32,6 +32,7 @@ jenkins_job_priority: 58
 jenkins_job_timeout: 180
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
+jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/buildfarm_perf_tests/raw/eloquent/tools/ros2_dependencies.repos
 repositories:

--- a/eloquent/ci-nightly-release.yaml
+++ b/eloquent/ci-nightly-release.yaml
@@ -26,6 +26,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 58
 jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*cyclonedds.* .*opensplice.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/eloquent/ros2.repos

--- a/eloquent/ci-overlay.yaml
+++ b/eloquent/ci-overlay.yaml
@@ -26,6 +26,7 @@ install_packages:
 jenkins_job_label: ci-agent
 jenkins_job_priority: 58
 jenkins_job_timeout: 240
+jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/ros2/raw/eloquent/ros2.repos
 repositories:

--- a/foxy/ci-benchmark.yaml
+++ b/foxy/ci-benchmark.yaml
@@ -31,6 +31,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_schedule: 30 23 * * *
 jenkins_job_timeout: 240
+jenkins_job_weight: 4
 package_selection_args: '--packages-above-depth 1 google_benchmark_vendor ament_cmake_google_benchmark performance_test_fixture'
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos

--- a/foxy/ci-nightly-connext.yaml
+++ b/foxy/ci-nightly-connext.yaml
@@ -24,6 +24,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*cyclonedds.* .*fastrtps.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos

--- a/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -20,6 +20,7 @@ jenkins_job_priority: 57
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-release
+jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -18,6 +18,7 @@ jenkins_job_priority: 57
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
+jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -16,6 +16,7 @@ jenkins_job_priority: 57
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-release
+jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -19,6 +19,7 @@ jenkins_job_priority: 57
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
+jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -17,6 +17,7 @@ jenkins_job_priority: 57
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-release
+jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos

--- a/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -15,6 +15,7 @@ jenkins_job_priority: 57
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
+jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos

--- a/foxy/ci-nightly-cyclonedds.yaml
+++ b/foxy/ci-nightly-cyclonedds.yaml
@@ -24,6 +24,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*fastrtps.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos

--- a/foxy/ci-nightly-debug.yaml
+++ b/foxy/ci-nightly-debug.yaml
@@ -28,6 +28,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos

--- a/foxy/ci-nightly-extra-rmw-release.yaml
+++ b/foxy/ci-nightly-extra-rmw-release.yaml
@@ -28,6 +28,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos
 repositories:

--- a/foxy/ci-nightly-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-fastrtps-dynamic.yaml
@@ -24,6 +24,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos

--- a/foxy/ci-nightly-fastrtps.yaml
+++ b/foxy/ci-nightly-fastrtps.yaml
@@ -24,6 +24,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos

--- a/foxy/ci-nightly-performance.yaml
+++ b/foxy/ci-nightly-performance.yaml
@@ -32,6 +32,7 @@ jenkins_job_priority: 57
 jenkins_job_timeout: 180
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
+jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/buildfarm_perf_tests/raw/master/tools/ros2_dependencies.repos
 repositories:

--- a/foxy/ci-nightly-release.yaml
+++ b/foxy/ci-nightly-release.yaml
@@ -28,6 +28,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos

--- a/foxy/ci-overlay.yaml
+++ b/foxy/ci-overlay.yaml
@@ -26,6 +26,7 @@ install_packages:
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_timeout: 240
+jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/ros2/raw/foxy/ros2.repos
 repositories:

--- a/rolling/ci-benchmark.yaml
+++ b/rolling/ci-benchmark.yaml
@@ -31,6 +31,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 30 23 * * *
 jenkins_job_timeout: 240
+jenkins_job_weight: 4
 package_selection_args: '--packages-above-depth 1 google_benchmark_vendor ament_cmake_google_benchmark performance_test_fixture'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos

--- a/rolling/ci-nightly-connext.yaml
+++ b/rolling/ci-nightly-connext.yaml
@@ -25,6 +25,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*cyclonedds.* .*fastrtps.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos

--- a/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -21,6 +21,7 @@ jenkins_job_priority: 50
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-release
+jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos

--- a/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -19,6 +19,7 @@ jenkins_job_priority: 50
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
+jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos

--- a/rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -17,6 +17,7 @@ jenkins_job_priority: 50
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-release
+jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos

--- a/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -20,6 +20,7 @@ jenkins_job_priority: 50
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
+jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos

--- a/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -18,6 +18,7 @@ jenkins_job_priority: 50
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-release
+jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos

--- a/rolling/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -16,6 +16,7 @@ jenkins_job_priority: 50
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
+jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos

--- a/rolling/ci-nightly-cyclonedds.yaml
+++ b/rolling/ci-nightly-cyclonedds.yaml
@@ -25,6 +25,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*fastrtps.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos

--- a/rolling/ci-nightly-debug.yaml
+++ b/rolling/ci-nightly-debug.yaml
@@ -29,6 +29,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos

--- a/rolling/ci-nightly-extra-rmw-release.yaml
+++ b/rolling/ci-nightly-extra-rmw-release.yaml
@@ -29,6 +29,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:

--- a/rolling/ci-nightly-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-fastrtps-dynamic.yaml
@@ -25,6 +25,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos

--- a/rolling/ci-nightly-fastrtps.yaml
+++ b/rolling/ci-nightly-fastrtps.yaml
@@ -25,6 +25,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos

--- a/rolling/ci-nightly-performance.yaml
+++ b/rolling/ci-nightly-performance.yaml
@@ -32,6 +32,7 @@ jenkins_job_priority: 50
 jenkins_job_timeout: 180
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
+jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/buildfarm_perf_tests/raw/master/tools/ros2_dependencies.repos
 repositories:

--- a/rolling/ci-nightly-release.yaml
+++ b/rolling/ci-nightly-release.yaml
@@ -29,6 +29,7 @@ jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
+jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos

--- a/rolling/ci-overlay.yaml
+++ b/rolling/ci-overlay.yaml
@@ -27,6 +27,7 @@ install_packages:
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 240
+jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:


### PR DESCRIPTION
This is needed to enable unified our build agents for CI
jobs (https://github.com/ros2/ros_buildfarm_config/issues/141)


Once this is deployed I'm pretty sure the heavy job behavior will prevent jobs from being queued on the single-executor ci-agents. My solution for that is to bump those up to four executors while we figure out the priority settling.