### PR TITLE
Use https for Jenkins url.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -103,7 +103,7 @@ distributions:
       ufv8: rolling/release-focal-arm64-build.yaml
     source_builds:
       default: rolling/source-build.yaml
-jenkins_url: http://build.ros2.org
+jenkins_url: https://build.ros2.org
 notification_emails:
   - steven+build.ros2.org@openrobotics.org
 prerequisites:


### PR DESCRIPTION
The new Jenkins deployment has https enabled and will redirect from http.