### PR TITLE
Enable rviz_assimp_vendor builds for RHEL 8

### DIFF
--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -53,7 +53,6 @@ package_blacklist:
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
 - ros2trace  # Not yet generated for RHEL
 - ros_canopen  # Not yet generated for RHEL
-- rviz_assimp_vendor  # RPM for assimp is not yet stable
 - sdformat_test_files  # sdformat has no RPM packages for RHEL 8
 - sdformat_urdf  # sdformat has no RPM packages for RHEL 8
 - serial_driver  # Not yet generated for RHEL


### PR DESCRIPTION
While we wait for the system package to resolve a CMake problem, there is a workaround patch in the release repository to force this package to build from source.