### PR TITLE
Enable packages for RHEL which require PCL

### DIFF
--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -35,7 +35,6 @@ package_blacklist:
 - marti_status_msgs  # Requires release with bloom >= 0.10.2
 - marti_visualization_msgs  # Requires release with bloom >= 0.10.2
 - mrpt2  # ffmpeg has no RPM package in supported repositories
-- phidgets_msgs  # Requires release with bloom >= 0.10.2
 - rc_dynamics_api  # Not yet generated for RHEL
 - rc_genicam_api  # Not yet generated for RHEL
 - rc_genicam_driver  # Not yet generated for RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -27,7 +27,6 @@ package_blacklist:
 - control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 8
 - gazebo_dev  # Gazebo has no RPM package
 - grbl_ros  # Not yet generated for RHEL
-- ifm3d_core  # pcl-devel has no RPM package for RHEL 8
 - marti_can_msgs  # Requires release with bloom >= 0.10.2
 - marti_common_msgs  # Requires release with bloom >= 0.10.2
 - marti_dbw_msgs  # Requires release with bloom >= 0.10.2
@@ -36,7 +35,6 @@ package_blacklist:
 - marti_status_msgs  # Requires release with bloom >= 0.10.2
 - marti_visualization_msgs  # Requires release with bloom >= 0.10.2
 - mrpt2  # ffmpeg has no RPM package in supported repositories
-- pcl_conversions  # pcl-devel has no RPM package for RHEL 8
 - phidgets_msgs  # Requires release with bloom >= 0.10.2
 - rc_dynamics_api  # Not yet generated for RHEL
 - rc_genicam_api  # Not yet generated for RHEL


### PR DESCRIPTION
PCL is now available for RHEL 8 via EPEL: https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2021-acd9e0a562