### PR TITLE
Don't build ignition packages for RHEL

### DIFF
--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -27,6 +27,7 @@ package_blacklist:
 - control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 8
 - gazebo_dev  # Gazebo has no RPM package
 - grbl_ros  # Not yet generated for RHEL
+- ign_rviz_common  # ignition has no RPM packages for RHEL
 - marti_can_msgs  # Requires release with bloom >= 0.10.2
 - marti_common_msgs  # Requires release with bloom >= 0.10.2
 - marti_dbw_msgs  # Requires release with bloom >= 0.10.2
@@ -38,6 +39,8 @@ package_blacklist:
 - rc_dynamics_api  # Not yet generated for RHEL
 - rc_genicam_api  # Not yet generated for RHEL
 - rc_genicam_driver  # Not yet generated for RHEL
+- ros_ign_bridge  # ignition has no RPM packages for RHEL
+- ros_ign_gazebo  # ignition has no RPM packages for RHEL
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
 - ros2trace  # Not yet generated for RHEL
 - sdformat_test_files  # sdformat has no RPM packages for RHEL 8


### PR DESCRIPTION
We don't have ignition packages for RHEL, so we shouldn't try to build these packages. They will always fail to build.