### PR TITLE
Trigger benchmark jobs when the upstream job completes

### DIFF
--- a/foxy/ci-benchmark.yaml
+++ b/foxy/ci-benchmark.yaml
@@ -29,8 +29,9 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
-jenkins_job_schedule: 30 23 * * *
 jenkins_job_timeout: 240
+jenkins_job_upstream_triggers:
+- nightly-extra-rmw-release
 jenkins_job_weight: 4
 package_selection_args: '--packages-above-depth 1 google_benchmark_vendor ament_cmake_google_benchmark performance_test_fixture'
 repos_files:

--- a/rolling/ci-benchmark.yaml
+++ b/rolling/ci-benchmark.yaml
@@ -29,8 +29,9 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
-jenkins_job_schedule: 30 23 * * *
 jenkins_job_timeout: 240
+jenkins_job_upstream_triggers:
+- nightly-extra-rmw-release
 jenkins_job_weight: 4
 package_selection_args: '--packages-above-depth 1 google_benchmark_vendor ament_cmake_google_benchmark performance_test_fixture'
 repos_files:


### PR DESCRIPTION
1. There's really no reason to run the benchmarks if the underlay job fails for that night and is therefore the same as the previous run.
2. The Foxy job should really be run every 3 nights like the rest of the Foxy CI jobs. It's a waste of time to run it every night.