### PR TITLE
Add in individual package documentation jobs for Rolling.

### DIFF
--- a/rolling/doc-build.yaml
+++ b/rolling/doc-build.yaml
@@ -5,7 +5,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: 3
 canonical_base_url: http://docs.ros.org/en
 documentation_type: rosdoc2
-jenkins_job_priority: 87
+jenkins_job_priority: 89
 jenkins_job_timeout: 120
 notifications:
   committers: false

--- a/rolling/doc-build.yaml
+++ b/rolling/doc-build.yaml
@@ -1,0 +1,59 @@
+%YAML 1.1
+# ROS buildfarm doc-build file
+---
+build_environment_variables:
+  ROS_PYTHON_VERSION: 3
+canonical_base_url: http://docs.ros.org/en
+documentation_type: rosdoc2
+jenkins_job_priority: 87
+jenkins_job_timeout: 120
+notifications:
+  committers: false
+  emails:
+  - clalancette+buildfarm@osrfoundation.org
+  maintainers: false
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQgA
+    PgIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgBYhBMHPbjHmut6IaLFytPQu1vur
+    F8ZUBQJgsdhRBQkLTMW7AAoJEPQu1vurF8ZUTMwP/3f7EkOPIFjUdRmpNJ2db4iB
+    RQu5b2SJRG+KIdbvQBzKUBMV6/RUhEDPjhXZI3zDevzBewvAMKkqs2Q1cWo9WV7Z
+    PyTkvSyey/Tjn+PozcdvzkvrEjDMftIk8E1WzLGq7vnPLZ1q/b6Vq4H373Z+EDWa
+    DaDwW72CbCBLWAVtqff80CwlI2x8fYHKr3VBUnwcXNHR4+nRABfAWnaU4k+oTshC
+    Qucsd8vitNfsSXrKuKyz91IRHRPnJjx8UvGU4tRGfrHkw1505EZvgP02vXeRyWBR
+    fKiL1vGy4tCSRDdZO3ms2J2m08VPv65HsHaWYMnO+rNJmMZj9d9JdL/9GRf5F6U0
+    quoIFL39BhUEvBynuqlrqistnyOhw8W/IQy/ymNzBMcMz6rcMjMwhkgm/LNXoSD1
+    1OrJu4ktQwRhwvGVarnB8ihwjsTxZFylaLmFSfaA+OAlOqCLS1OkIVMzjW+Ul6A6
+    qjiCEUOsnlf4CGlhzNMZOx3low6ixzEqKOcfECpeIj80a2fBDmWkcAAjlHu6VBhA
+    TUDG9e2xKLzV2Z/DLYsb3+n9QW7KO0yZKfiuUo6AYboAioQKn5jh3iRvjGh2Ujpo
+    22G+oae3PcCc7G+z12j6xIY709FQuA49dA2YpzMda0/OX4LP56STEveDRrO+CnV6
+    WE+F5FaIKwb72PL4rLi4
+    =i0tj
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repo.ros2.org/ubuntu/testing/
+targets:
+  ubuntu:
+    focal:
+      amd64:
+type: doc-build
+upload_credential_id: jenkins-agent
+upload_host: docs.ros.org
+upload_root: /var/www/docs.ros.org/en/ros2_packages/rolling
+upload_user: rosbot
+version: 2


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This takes advantage of the recently merged https://github.com/ros-infrastructure/ros_buildfarm/pull/880 .  Note that the configuration file here is almost exactly the same as the one I've been testing on the test buildfarm with https://github.com/ros-staging/ros_buildfarm_config/blob/staging/rolling/doc-build.yaml .  The only difference is that I've updated the credentials to be the ones we actually need to use to upload things to docs.ros.org.

Also note that this will end up uploading documentation to `/var/www/docs.ros.org/en/ros2_packages/rolling/<pkgname>` on the webhost.  That isn't the final URL that we want to serve the content from, but we can still go ahead with this while I sort out my `AliasMatch` configuration for Apache.