### PR TITLE
Enable doc builds for Rolling.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -100,7 +100,8 @@ distributions:
       nightly-performance: rolling/ci-nightly-performance.yaml
       nightly-release: rolling/ci-nightly-release.yaml
       overlay: rolling/ci-overlay.yaml
-    doc_builds: {}
+    doc_builds:
+      default: rolling/doc-build.yaml
     notification_emails:
       - steven+build.ros2.org@openrobotics.org
       - ros2-buildfarm-rolling@googlegroups.com


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>