### PR TITLE
Add a clang-tidy build to Rolling CI.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -63,6 +63,7 @@ distributions:
   rolling:
     ci_builds:
       benchmark: rolling/ci-benchmark.yaml
+      clang_tidy: rolling/ci-clang-tidy.yaml
       nightly-connext: rolling/ci-nightly-connext.yaml
       nightly-cross-vendor-connext-cyclonedds: rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
       nightly-cross-vendor-connext-fastrtps: rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml

--- a/index.yaml
+++ b/index.yaml
@@ -63,7 +63,7 @@ distributions:
   rolling:
     ci_builds:
       benchmark: rolling/ci-benchmark.yaml
-      clang_tidy: rolling/ci-clang-tidy.yaml
+      clang-tidy: rolling/ci-clang-tidy.yaml
       nightly-connext: rolling/ci-nightly-connext.yaml
       nightly-cross-vendor-connext-cyclonedds: rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
       nightly-cross-vendor-connext-fastrtps: rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml

--- a/rolling/ci-clang-tidy.yaml
+++ b/rolling/ci-clang-tidy.yaml
@@ -6,11 +6,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli'
 build_tool_test_args: '--ctest-args -L clang_tidy --pytest-args -m clang_tidy'
-install_packages:
-- default-jdk # for CycloneDDS
-- libasio-dev # for FastRTPS
-- libtinyxml2-dev # for FastRTPS
-- maven # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: H H * * 0

--- a/rolling/ci-clang-tidy.yaml
+++ b/rolling/ci-clang-tidy.yaml
@@ -1,0 +1,95 @@
+%YAML 1.1
+# ROS buildfarm ci-build file
+---
+build_environment_variables:
+  ROS_PYTHON_VERSION: '3'
+  RTI_NC_LICENSE_ACCEPTED: 'yes'
+build_tool: colcon
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli'
+build_tool_test_args: '--ctest-args -L clang_tidy --pytest-args -m clang_tidy'
+install_packages:
+- default-jdk # for CycloneDDS
+- libasio-dev # for FastRTPS
+- libtinyxml2-dev # for FastRTPS
+- maven # for CycloneDDS
+jenkins_job_label: ci-agent
+jenkins_job_priority: 50
+jenkins_job_schedule: H H * * 0
+jenkins_job_timeout: 300
+jenkins_job_weight: 4
+package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp image_tools'
+repos_files:
+- https://github.com/nuclearsandwich/ros2/raw/clang-tidy/ros2.repos
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQgA
+    PgIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgBYhBMHPbjHmut6IaLFytPQu1vur
+    F8ZUBQJgsdhRBQkLTMW7AAoJEPQu1vurF8ZUTMwP/3f7EkOPIFjUdRmpNJ2db4iB
+    RQu5b2SJRG+KIdbvQBzKUBMV6/RUhEDPjhXZI3zDevzBewvAMKkqs2Q1cWo9WV7Z
+    PyTkvSyey/Tjn+PozcdvzkvrEjDMftIk8E1WzLGq7vnPLZ1q/b6Vq4H373Z+EDWa
+    DaDwW72CbCBLWAVtqff80CwlI2x8fYHKr3VBUnwcXNHR4+nRABfAWnaU4k+oTshC
+    Qucsd8vitNfsSXrKuKyz91IRHRPnJjx8UvGU4tRGfrHkw1505EZvgP02vXeRyWBR
+    fKiL1vGy4tCSRDdZO3ms2J2m08VPv65HsHaWYMnO+rNJmMZj9d9JdL/9GRf5F6U0
+    quoIFL39BhUEvBynuqlrqistnyOhw8W/IQy/ymNzBMcMz6rcMjMwhkgm/LNXoSD1
+    1OrJu4ktQwRhwvGVarnB8ihwjsTxZFylaLmFSfaA+OAlOqCLS1OkIVMzjW+Ul6A6
+    qjiCEUOsnlf4CGlhzNMZOx3low6ixzEqKOcfECpeIj80a2fBDmWkcAAjlHu6VBhA
+    TUDG9e2xKLzV2Z/DLYsb3+n9QW7KO0yZKfiuUo6AYboAioQKn5jh3iRvjGh2Ujpo
+    22G+oae3PcCc7G+z12j6xIY709FQuA49dA2YpzMda0/OX4LP56STEveDRrO+CnV6
+    WE+F5FaIKwb72PL4rLi4
+    =i0tj
+    -----END PGP PUBLIC KEY BLOCK-----
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1.4.11 (GNU/Linux)
+
+    mQGiBEsy5KkRBADJbDSISoamRM5AA20bfAeBuhhaI+VaiCVcxw90sq9AI5lIc42F
+    WzM2acm8yplqWiehAqOLKd+iIrqNGZ+VavZEPTx7o06UZUMRoPBiTFaCwrQ5avKz
+    lt7ij8PRMVWNrJ7A2lDYXfFQVV1o3Xo06qVnv0KLLUmiur0LBu4H/oTH3wCgt+/I
+    D3LUKaMJsc77KwFBTjHB0EsD/26Z2Ud12f3urSNyN6VMWnP3rz6xsmtY4Qsmkbnr
+    JuduxCQBZv6bX1Cr2ulXkv0fFOr+s5OyUv7zyCPbxiJFh3Br7fJGb0b5/M208KPe
+    giITY9hMh/aUbKjXCPoOXPxSL6SWOWV8taR6903EFyLBN0qno/kXIBKnVqBZobgn
+    jIEPA/0fTnxtZtE7EpirGQMF2caJfv7/LCgXmRs9xAhgbE0/caoa1tnc79uaHmLZ
+    FtbGFoAO31YNYM/IUHtmabbGdvZ4oYUwDhjBevVvC7aI+XhuNGK5mU8qCLLSEUOl
+    CUr6BJq/0iFmjwjmwk9idZEYhqSNy2OoYJbq45rbHfbdKLEVrbQeUk9TIEJ1aWxk
+    ZXIgPHJvc2J1aWxkQHJvcy5vcmc+iGAEExECACAFAksy5KkCGwMGCwkIBwMCBBUC
+    CAMEFgIDAQIeAQIXgAAKCRBVI7rusB+hFmk7AJ0XsLp05KA8l3YzAumZfjSN04MZ
+    jQCfQHfp4aQUXdOCUtetVo0QZUX3IuO5Ag0ESzLkrhAIAOCuSC83VXYWf8gOMSzd
+    xwpsH/uLV9Wze2LGnajsJLjEOhcsz2BHfxqNXhYaE9aQaodPCpbUAkPq8tLbpXy0
+    SWRCx0F5RcplXx5vIWbP6TlfPbRpK70w7IWd6vsNrjwEHjlhOLcNcj42sp5pgx4b
+    dceK06k5Ml2hYovPnD9o2TYgjOqg5FHZ2g1J0103n/66bN/hZnpLaZJYQiPWCyq6
+    K0565i1k2Y7hgWB/OXqwaqCehqmLTvpyQGzE1UJvKLuYU+T+4hBnSPbT3KIi5fCz
+    lIwvxijOMcfbkLhzYQXcU0Rd1VItcd5nmPL4z97jBxzuhkgxXpGR4WGKhvsA2Z9Y
+    UtsAAwYH/3Bf44bTpD9bVADUdab3e7zm8iHfh9K/a83mIgDB7mHV6WuemQVTf/1d
+    eu4mI5WtpbOCoucybGfjGIIAcSxwIx6VfC7HSp4J51bOpHhbdDffUEk6QVsZjwoF
+    yn3W9W3ZVeTI+ch/Qoo5a98SnmdjN8eXI/qCuiXOHc6rXDXc2R0iox/1EAS8xGVd
+    cYZe7IWBO2CjCknyhLrWxZHoy+i1GCZ9KvPF/Ef2dmLhCydT73ZlumsY8N5vm76Q
+    ul1G7f8LNbnMgXQafRkPffrAXSVhGY3Z2IiBwFNgxcKTq479l7yedYRGeU1A+SYI
+    YmRFWHXt3rTkMlQSpxCsB0fAYfrwEqqISQQYEQIACQUCSzLkrgIbDAAKCRBVI7ru
+    sB+hFpryAJ4puo6cMZxa6wITHFAM/k84+aRijwCeItuWpUngP25xDuDGMsKarcNi
+    qYE=
+    =Vgio
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repo.ros2.org/ubuntu/testing
+  - http://repositories.ros.org/ubuntu/testing
+targets:
+  ubuntu:
+    focal:
+      amd64:
+type: ci-build
+version: 1

--- a/rolling/ci-clang-tidy.yaml
+++ b/rolling/ci-clang-tidy.yaml
@@ -3,7 +3,6 @@
 ---
 build_environment_variables:
   ROS_PYTHON_VERSION: '3'
-  RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON --no-warn-unused-cli'
 build_tool_test_args: '--ctest-args -L clang_tidy --pytest-args -m clang_tidy'

--- a/rolling/ci-clang-tidy.yaml
+++ b/rolling/ci-clang-tidy.yaml
@@ -19,7 +19,7 @@ jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp image_tools'
 repos_files:
-- https://github.com/nuclearsandwich/ros2/raw/clang-tidy/ros2.repos
+- https://github.com/ros2/ros2/raw/spaceros/ros2.repos
 repositories:
   keys:
   - |


### PR DESCRIPTION
Adds a CI build running clang-tidy. Before this can be merged we'll need https://github.com/ros2/ros2/pull/1165 to actually have clang-tidy enabled for the target repos file but I'd like some feedback on the configuration.