### PR TITLE
Remove the distribution name from the rolling doc_root.

### DIFF
--- a/rolling/doc-build.yaml
+++ b/rolling/doc-build.yaml
@@ -54,6 +54,6 @@ targets:
 type: doc-build
 upload_credential_id: jenkins-agent
 upload_host: docs.ros.org
-upload_root: /var/www/docs.ros.org/en/ros2_packages/rolling
+upload_root: /var/www/docs.ros.org/en/ros2_packages
 upload_user: rosbot
 version: 2


### PR DESCRIPTION
The code will automatically add this.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>