### PR TITLE
Update RHEL build exclusion lists for Galactic and Rolling

### DIFF
--- a/galactic/release-rhel-build.yaml
+++ b/galactic/release-rhel-build.yaml
@@ -62,6 +62,7 @@ package_blacklist:
 - popf  # COIN-OR packages have no RPM packages for RHEL 8
 - ros_ign_bridge  # ignition has no RPM packages for RHEL
 - ros_ign_gazebo  # ignition has no RPM packages for RHEL
+- ros_ign_interfaces  # ignition has no RPM packages for RHEL
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
 - sdformat_test_files  # sdformat has no RPM packages for RHEL 8
 - sdformat_urdf  # sdformat has no RPM packages for RHEL 8
@@ -69,6 +70,7 @@ package_blacklist:
 - tracetools_launch  # Not yet generated for RHEL
 - tracetools_test  # Not yet generated for RHEL
 - ublox_gps  # asio has no RPM package for RHEL 8
+- usb_cam  # Not yet generated for RHEL
 - warehouse_ros_mongo  # mongodb has no RPM package for RHEL 8
 - webots_ros2  # python-imaging has no RPM package for RHEL 8
 - webots_ros2_abb  # python-imaging has no RPM package for RHEL 8

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -51,6 +51,9 @@ package_blacklist:
 - rc_dynamics_api  # Not yet generated for RHEL
 - rc_genicam_api  # Not yet generated for RHEL
 - rc_genicam_driver  # Not yet generated for RHEL
+- rmf_demos_dashboard_resources  # python3-flask-cors has no RPM packages for RHEL
+- rmf_demos_maps  # python3-flask-cors has no RPM packages for RHEL
+- rmf_demos_tasks  # python3-flask-cors has no RPM packages for RHEL
 - ros_ign_bridge  # ignition has no RPM packages for RHEL
 - ros_ign_gazebo  # ignition has no RPM packages for RHEL
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
@@ -68,6 +71,7 @@ package_blacklist:
 - tracetools_trace  # Not yet generated for RHEL
 - ublox_gps  # asio has no RPM package for RHEL 8
 - udp_driver  # Not yet generated for RHEL
+- usb_cam  # Not yet generated for RHEL
 - warehouse_ros_mongo  # mongodb has no RPM package for RHEL
 - webots_ros2  # Not yet generated for RHEL
 - webots_ros2_abb  # Not yet generated for RHEL


### PR DESCRIPTION
Some of these packages are new, and some were unblocked by upstream packages which are now buildable and were re-enabled.