### PR TITLE
Switch rolling sync threshold from count to required packages.

### DIFF
--- a/rolling/release-build.yaml
+++ b/rolling/release-build.yaml
@@ -16,7 +16,7 @@ notifications:
   - ros2-buildfarm-rolling@googlegroups.com
   maintainers: true
 sync:
-  package_count: 262
+  packages: [desktop]
 repositories:
   keys:
   - |

--- a/rolling/release-build.yaml
+++ b/rolling/release-build.yaml
@@ -16,6 +16,7 @@ notifications:
   - ros2-buildfarm-rolling@googlegroups.com
   maintainers: true
 sync:
+  package_count: 500
   packages: [desktop]
 repositories:
   keys:

--- a/rolling/release-focal-arm64-build.yaml
+++ b/rolling/release-focal-arm64-build.yaml
@@ -13,7 +13,7 @@ notifications:
   - ros2-buildfarm-rolling@googlegroups.com
   maintainers: true
 sync:
-  package_count: 262
+  packages: [desktop]
 repositories:
   keys:
   - |

--- a/rolling/release-focal-arm64-build.yaml
+++ b/rolling/release-focal-arm64-build.yaml
@@ -13,6 +13,7 @@ notifications:
   - ros2-buildfarm-rolling@googlegroups.com
   maintainers: true
 sync:
+  package_count: 500
   packages: [desktop]
 repositories:
   keys:

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -102,7 +102,7 @@ package_ignore_list:
 - rosidl_typesupport_gurumdds_cpp  # No RPM package for GurumDDS
 - rti_connext_dds_cmake_module  # No RPM package for Connext
 sync:
-  package_count: 262
+  packages: [desktop]
 repositories:
   keys:
   - |

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -102,6 +102,7 @@ package_ignore_list:
 - rosidl_typesupport_gurumdds_cpp  # No RPM package for GurumDDS
 - rti_connext_dds_cmake_module  # No RPM package for Connext
 sync:
+  package_count: 400
   packages: [desktop]
 repositories:
   keys:


### PR DESCRIPTION
For most ROS distributions we want to periodically ratchet up the
package count for sync thresholds. However Rolling is meant to be
somewhat volatile as large changes are made.

A large enough number of ancillary packages have been introduced to
Rolling that the "base" numeric package count is no longer sufficient to
guarantee the presence of ROS core packages. So let's instead use the
required packages sync criteria and require the presence of ros_desktop
which will in turn require the ROS core and a relatively healthy ROS
system to be available.