### PR TITLE
Update RHEL build exclusion lists for Galactic and Rolling

### DIFF
--- a/galactic/release-rhel-build.yaml
+++ b/galactic/release-rhel-build.yaml
@@ -67,10 +67,8 @@ package_blacklist:
 - sdformat_test_files  # sdformat has no RPM packages for RHEL 8
 - sdformat_urdf  # sdformat has no RPM packages for RHEL 8
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
-- tracetools_launch  # Not yet generated for RHEL
-- tracetools_test  # Not yet generated for RHEL
 - ublox_gps  # asio has no RPM package for RHEL 8
-- usb_cam  # Not yet generated for RHEL
+- usb_cam  # ffmpeg has no RPM package for RHEL
 - warehouse_ros_mongo  # mongodb has no RPM package for RHEL 8
 - webots_ros2  # python-imaging has no RPM package for RHEL 8
 - webots_ros2_abb  # python-imaging has no RPM package for RHEL 8

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -15,21 +15,15 @@ notifications:
   - scott@openrobotics.org
   maintainers: false
 package_blacklist:
-- acado_vendor  # Not yet generated for RHEL
+- acado_vendor  # Requires unreleased changes
 - async_web_server_cpp  # Not yet generated for RHEL
-- autoware_auto_msgs  # Not yet generated for RHEL
 - backward_ros  # Not yet generated for RHEL
 - bno055  # Not yet generated for RHEL
 - bosch_locator_bridge  # libpoco-dev has no RPM package for RHEL 8
-- canopen_402  # Not yet generated for RHEL
-- canopen_chain_node  # Not yet generated for RHEL
-- canopen_master  # Not yet generated for RHEL
-- canopen_motor_node  # Not yet generated for RHEL
 - cartographer  # RPM for ceres-solver is not yet stable
 - control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 8
 - dynamic_edt_3d  # Not yet generated for RHEL
 - gazebo_dev  # Gazebo has no RPM package
-- geometric_shapes  # Not yet generated for RHEL
 - grbl_ros  # Not yet generated for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL
 - marti_can_msgs  # Requires release with bloom >= 0.10.2
@@ -51,27 +45,16 @@ package_blacklist:
 - rc_dynamics_api  # Not yet generated for RHEL
 - rc_genicam_api  # Not yet generated for RHEL
 - rc_genicam_driver  # Not yet generated for RHEL
-- rmf_demos_dashboard_resources  # python3-flask-cors has no RPM packages for RHEL
-- rmf_demos_maps  # python3-flask-cors has no RPM packages for RHEL
-- rmf_demos_tasks  # python3-flask-cors has no RPM packages for RHEL
 - ros_ign_bridge  # ignition has no RPM packages for RHEL
 - ros_ign_gazebo  # ignition has no RPM packages for RHEL
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
-- ros2trace  # Not yet generated for RHEL
 - sdformat_test_files  # sdformat has no RPM packages for RHEL 8
 - sdformat_urdf  # sdformat has no RPM packages for RHEL 8
 - serial_driver  # Not yet generated for RHEL
-- socketcan_bridge  # Not yet generated for RHEL
-- socketcan_interface  # Not yet generated for RHEL
-- test_osrf_testing_tools_cpp  # Doesn't install anything
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
-- tracetools_launch  # Not yet generated for RHEL
-- tracetools_read  # Not yet generated for RHEL
-- tracetools_test  # Not yet generated for RHEL
-- tracetools_trace  # Not yet generated for RHEL
 - ublox_gps  # asio has no RPM package for RHEL 8
 - udp_driver  # Not yet generated for RHEL
-- usb_cam  # Not yet generated for RHEL
+- usb_cam  # ffmpeg has no RPM package for RHEL
 - warehouse_ros_mongo  # mongodb has no RPM package for RHEL
 - webots_ros2  # Not yet generated for RHEL
 - webots_ros2_abb  # Not yet generated for RHEL


### PR DESCRIPTION
In this round, I'm only enabling builds which were unblocked by rosdep rules becoming resolvable and external packages performing Bloom generation where previously RHEL was not listed in the distribution.yaml.

A few of the packages I'm de-listing in Rolling are simply no longer a part of the distribution, so there is no reason to list them.

I also updated a couple of justifications to reflect reality.