### PR TITLE
Update RHEL build exclusion lists for Galactic and Rolling

### DIFF
--- a/galactic/release-rhel-build.yaml
+++ b/galactic/release-rhel-build.yaml
@@ -29,6 +29,7 @@ package_blacklist:
 - libmavconn  # asio has no RPM package for RHEL 8
 - moveit_common  # libogre-dev has no RPM package for RHEL
 - mrpt2  # ffmpeg has no RPM package in supported repositories
+- mrt_cmake_modules  # lcov has no RPM package for RHEL 8
 - nav2_amcl  # lcov has no RPM package for RHEL 8
 - nav2_behavior_tree  # lcov has no RPM package for RHEL 8
 - nav2_bringup  # lcov has no RPM package for RHEL 8
@@ -58,7 +59,6 @@ package_blacklist:
 - ntpd_driver  # libpoco-dev has no RPM package for RHEL 8
 - octomap  # libqglviewer-dev-qt5 has no RPM for RHEL
 - ompl  # opende has no RPM package for RHEL
-- pcl_ros  # pcl RPM has no visualization component for RHEL
 - popf  # COIN-OR packages have no RPM packages for RHEL 8
 - ros_ign_bridge  # ignition has no RPM packages for RHEL
 - ros_ign_gazebo  # ignition has no RPM packages for RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -35,11 +35,11 @@ package_blacklist:
 - marti_visualization_msgs  # Requires release with bloom >= 0.10.2
 - moveit_common  # libogre-dev has no RPM package for RHEL
 - mrpt2  # ffmpeg has no RPM package in supported repositories
+- mrt_cmake_modules  # lcov has no RPM package for RHEL 8
 - ntpd_driver  # libpoco-dev has no RPM package for RHEL 8
 - octomap  # Not yet generated for RHEL
 - octovis  # Not yet generated for RHEL
 - ompl  # opende has no RPM package for RHEL
-- pcl_ros  # pcl RPM has no visualization component for RHEL
 - plotjuggler  # Not yet generated for RHEL
 - random_numbers  # Not yet generated for RHEL
 - rc_dynamics_api  # Not yet generated for RHEL
@@ -47,6 +47,7 @@ package_blacklist:
 - rc_genicam_driver  # Not yet generated for RHEL
 - ros_ign_bridge  # ignition has no RPM packages for RHEL
 - ros_ign_gazebo  # ignition has no RPM packages for RHEL
+- ros_ign_interfaces  # ignition has no RPM packages for RHEL
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
 - sdformat_test_files  # sdformat has no RPM packages for RHEL 8
 - sdformat_urdf  # sdformat has no RPM packages for RHEL 8


### PR DESCRIPTION
PCL in EPEL 8 now has visualization support, so `pcl_ros` can build.