### PR TITLE
Add alternative rmw packages to skip_rosdep_keys for clang-tidy job.

### DIFF
--- a/rolling/ci-clang-tidy.yaml
+++ b/rolling/ci-clang-tidy.yaml
@@ -81,6 +81,11 @@ repositories:
   urls:
   - http://repo.ros2.org/ubuntu/testing
   - http://repositories.ros.org/ubuntu/testing
+skip_rosdep_keys:
+  - rmw_connextdds
+  - rmw_fastrtps_cpp
+  - rmw_fastrtps_dynamic_cpp
+  - rosidl_typesupport_fastrtps_c
 targets:
   ubuntu:
     focal:


### PR DESCRIPTION
These dependencies are being resolved to rolling binary packages in the
underlay when they should just be ignored due to the hard-coded dependencies in rmw_implementation to make up for the lack of full group support in Bloom and ros_buildfarm.

Another possible option, used by the other CI jobs, is to keep
everything in the repos file and use package selection arguments to
ignore the in-workspace dependencies. But that will result in our repos
file containing more than the minimum package set for the clang-tidy
target.

I did branch-deploy this job yesterday to make sure that this change would be sufficient to create a working build. Here's the result https://build.ros2.org/view/Rci/job/Rci__clang-tidy_ubuntu_focal_amd64/4/