### PR TITLE
Skip additional rosdep keys.

### DIFF
--- a/rolling/ci-clang-tidy.yaml
+++ b/rolling/ci-clang-tidy.yaml
@@ -82,6 +82,10 @@ repositories:
   - http://repo.ros2.org/ubuntu/testing
   - http://repositories.ros.org/ubuntu/testing
 skip_rosdep_keys:
+  - composition
+  - demo_nodes_py
+  - ikos
+  - lifecycle
   - rmw_connextdds
   - rmw_fastrtps_cpp
   - rmw_fastrtps_dynamic_cpp


### PR DESCRIPTION
Needed after changes to the target repos file to include more packages.
Some of the added skipped keys are ROS packages which are not included
in the repos file nor are they required for the build to run but are
referenced as dependencies of auxiliary packages.