### PR TITLE
Blacklist failing package pending a fix upstream.

### DIFF
--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -23,6 +23,7 @@ package_blacklist:
 - cartographer  # RPM for ceres-solver is not yet stable
 - control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 8
 - dynamic_edt_3d  # Not yet generated for RHEL
+- four_wheel_steering_msgs # https://github.com/ros-drivers/four_wheel_steering_msgs/pull/7
 - gazebo_dev  # Gazebo has no RPM package
 - grbl_ros  # Not yet generated for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -23,7 +23,7 @@ package_blacklist:
 - cartographer  # RPM for ceres-solver is not yet stable
 - control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 8
 - dynamic_edt_3d  # Not yet generated for RHEL
-- four_wheel_steering_msgs # https://github.com/ros-drivers/four_wheel_steering_msgs/pull/7
+- four_wheel_steering_msgs  # https://github.com/ros-drivers/four_wheel_steering_msgs/pull/7
 - gazebo_dev  # Gazebo has no RPM package
 - grbl_ros  # Not yet generated for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL


### PR DESCRIPTION
https://github.com/ros-drivers/four_wheel_steering_msgs/pull/7 has been opened upstream.
In the meantime we can blacklist the package on RHEL.