### PR TITLE
Export ROS_VERSION as 2

### DIFF
--- a/galactic/release-build.yaml
+++ b/galactic/release-build.yaml
@@ -5,6 +5,7 @@ abi_incompatibility_assumed: true
 
 build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
+  ROS_VERSION: '2'
 
 jenkins_binary_job_priority: 86
 jenkins_binary_job_timeout: 120


### PR DESCRIPTION
Needed for:

<member_of_group condition="$ROS_VERSION == 2">

I hope this fixes:

https://build.ros2.org/view/Rbin_uF64/job/Rbin_uF64__plotjuggler_msgs__ubuntu_focal_amd64__binary/73/consoleFull