### PR TITLE
Enable ccache and increase timeout for Rolling debug CI job.

### DIFF
--- a/rolling/ci-nightly-debug.yaml
+++ b/rolling/ci-nightly-debug.yaml
@@ -28,7 +28,7 @@ install_packages:
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
-jenkins_job_timeout: 300
+jenkins_job_timeout: 360
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:

--- a/rolling/ci-nightly-debug.yaml
+++ b/rolling/ci-nightly-debug.yaml
@@ -100,6 +100,7 @@ repositories:
   urls:
   - http://repo.ros2.org/ubuntu/testing
   - http://repositories.ros.org/ubuntu/testing
+shared_ccache: true
 targets:
   ubuntu:
     focal:


### PR DESCRIPTION
If the ccache change shows improvement in build times over the next week we'll update other CI jobs as well.