### PR TITLE
Blacklist libmavconn on rolling-rhel.

### DIFF
--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -28,6 +28,7 @@ package_blacklist:
 - ign_rviz_common  # ignition has no RPM packages for RHEL
 - io_context  # asio has no RPM package for RHEL 8
 - joint_state_broadcaster  # Build failures on RHEL
+- libmavconn  # asio has no RPM package for RHEL 8
 - microstrain_inertial_msgs  # Not yet generated for RHEL
 - moveit_common  # libogre-dev has no RPM package for RHEL
 - mrpt2  # ffmpeg has no RPM package in supported repositories


### PR DESCRIPTION
There is no asio package for RHEL 8 in the accepted repositories for ROS.