### PR TITLE
Blacklist rmf_robot_sim_ignition_plugins for rolling-rhel.

### DIFF
--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -38,6 +38,7 @@ package_blacklist:
 - ompl  # opende has no RPM package for RHEL
 - random_numbers  # Not yet generated for RHEL
 - rc_dynamics_api  # Not yet generated for RHEL
+- rmf_robot_sim_ignition_plugins  # ignition has no RPM packages for RHEL
 - ros_ign_bridge  # ignition has no RPM packages for RHEL
 - ros_ign_gazebo  # ignition has no RPM packages for RHEL
 - ros_ign_interfaces  # ignition has no RPM packages for RHEL


### PR DESCRIPTION
Ignition has no RPM packages for RHEL.