### PR TITLE
Blacklist rmf_robot_sim_common on rolling-rhel.

### DIFF
--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -38,6 +38,7 @@ package_blacklist:
 - ompl  # opende has no RPM package for RHEL
 - random_numbers  # Not yet generated for RHEL
 - rc_dynamics_api  # Not yet generated for RHEL
+- rmf_robot_sim_common  # Build failures on RHEL https://github.com/open-rmf/rmf_simulation/issues/67
 - ros_ign_bridge  # ignition has no RPM packages for RHEL
 - ros_ign_gazebo  # ignition has no RPM packages for RHEL
 - ros_ign_interfaces  # ignition has no RPM packages for RHEL


### PR DESCRIPTION
Package build fails. Upstream issue https://github.com/open-rmf/rmf_simulation/issues/67