### PR TITLE
Blacklist rmf_demos_maps on rolling-rhel.

### DIFF
--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -40,6 +40,7 @@ package_blacklist:
 - ompl  # opende has no RPM package for RHEL
 - random_numbers  # Not yet generated for RHEL
 - rc_dynamics_api  # Not yet generated for RHEL
+- rmf_demos_maps  # Build failures on RHEL https://github.com/open-rmf/rmf_demos/issues/119
 - rmf_robot_sim_common  # Build failures on RHEL https://github.com/open-rmf/rmf_simulation/issues/67
 - rmf_robot_sim_ignition_plugins  # ignition has no RPM packages for RHEL
 - rmf_traffic_ros2  # Build failures on RHEl https://github.com/open-rmf/rmf_ros2/issues/156


### PR DESCRIPTION
Build failures on RHEL.
Upstream issue: https://github.com/open-rmf/rmf_demos/issues/119