### PR TITLE
Add a new CI job for building Rolling on Focal

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -79,6 +79,7 @@ distributions:
       nightly-performance: rolling/ci-nightly-performance.yaml
       nightly-release: rolling/ci-nightly-release.yaml
       overlay: rolling/ci-overlay.yaml
+      rolling-on-focal: rolling/ci-rolling-on-focal.yaml
     doc_builds:
       default: rolling/doc-build.yaml
     notification_emails:

--- a/rolling/ci-rolling-on-focal.yaml
+++ b/rolling/ci-rolling-on-focal.yaml
@@ -1,0 +1,59 @@
+%YAML 1.1
+# ROS buildfarm ci-build file
+---
+build_environment_variables:
+  ROS_PYTHON_VERSION: '3'
+build_tool: colcon
+build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
+build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE "(linter|performance|xfail| placeholder-with-space )" --pytest-args -m "not linter and not performance and not xfail"'
+jenkins_job_label: ci-agent
+jenkins_job_priority: 50
+jenkins_job_schedule: 15 23 * * 6
+jenkins_job_timeout: 300
+jenkins_job_weight: 4
+package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* --packages-up-to ros_base rviz2'
+repos_files:
+- https://github.com/ros2/ros2/raw/master/ros2.repos
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQgA
+    PgIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgBYhBMHPbjHmut6IaLFytPQu1vur
+    F8ZUBQJgsdhRBQkLTMW7AAoJEPQu1vurF8ZUTMwP/3f7EkOPIFjUdRmpNJ2db4iB
+    RQu5b2SJRG+KIdbvQBzKUBMV6/RUhEDPjhXZI3zDevzBewvAMKkqs2Q1cWo9WV7Z
+    PyTkvSyey/Tjn+PozcdvzkvrEjDMftIk8E1WzLGq7vnPLZ1q/b6Vq4H373Z+EDWa
+    DaDwW72CbCBLWAVtqff80CwlI2x8fYHKr3VBUnwcXNHR4+nRABfAWnaU4k+oTshC
+    Qucsd8vitNfsSXrKuKyz91IRHRPnJjx8UvGU4tRGfrHkw1505EZvgP02vXeRyWBR
+    fKiL1vGy4tCSRDdZO3ms2J2m08VPv65HsHaWYMnO+rNJmMZj9d9JdL/9GRf5F6U0
+    quoIFL39BhUEvBynuqlrqistnyOhw8W/IQy/ymNzBMcMz6rcMjMwhkgm/LNXoSD1
+    1OrJu4ktQwRhwvGVarnB8ihwjsTxZFylaLmFSfaA+OAlOqCLS1OkIVMzjW+Ul6A6
+    qjiCEUOsnlf4CGlhzNMZOx3low6ixzEqKOcfECpeIj80a2fBDmWkcAAjlHu6VBhA
+    TUDG9e2xKLzV2Z/DLYsb3+n9QW7KO0yZKfiuUo6AYboAioQKn5jh3iRvjGh2Ujpo
+    22G+oae3PcCc7G+z12j6xIY709FQuA49dA2YpzMda0/OX4LP56STEveDRrO+CnV6
+    WE+F5FaIKwb72PL4rLi4
+    =i0tj
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repo.ros2.org/ubuntu/main
+repository_names: [variants]
+targets:
+  ubuntu:
+    focal:
+      amd64:
+type: ci-build
+upload_directory: rolling-on-focal
+version: 1


### PR DESCRIPTION
This job should continue to build Rolling on Ubuntu Focal after Rolling begins to target Ubuntu Jammy in the near future. Some specific differences in this job from the normal nightly jobs:
- The scope is smaller - only ros-base and rviz2 at the moment
- It doesn't run linters or performance tests to save compute
- The resulting tarball is uploaded to repo.ros2.org
- Only CycloneDDS and Fast-DDS are supported
- No ROS 1, and no bridge