### PR TITLE
Validate YAML style in CI and PR builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,3 +20,9 @@ jobs:
       env:
         PYTHONPATH: ${{github.workspace}}/ros_buildfarm
       run: ${{github.workspace}}/ros_buildfarm/scripts/misc/validate_config_index.py file://${{github.workspace}}/index.yaml
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Validate YAML style
+      run: yamllint .

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,7 @@
+---
+extends: default
+
+rules:
+  indentation:
+    indent-sequences: false
+  line-length: disable


### PR DESCRIPTION
~~Requires #201~~
~~Requires #202~~
~~Requires #203~~

We're pretty close to conforming to the `default` rule set for yamllint. The only deviations are that this repository doesn't indent lists, and that we have a lot of ridiculously long lines, so I disabled the line length check.