### PR TITLE
Install colcon-bash when building rolling-on-focal

### DIFF
--- a/rolling/ci-rolling-on-focal.yaml
+++ b/rolling/ci-rolling-on-focal.yaml
@@ -6,6 +6,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE "(linter|performance|xfail| placeholder-with-space )" --pytest-args -m "not linter and not performance and not xfail"'
+install_packages:
+- python3-colcon-bash
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * 6


### PR DESCRIPTION
One of the general goals of the CI jobs is to create a minimal environment in an effort to assert dependencies are declared properly. The purpose of the rolling-on-focal job specifically is to create a distributable archive for use in the same way our archives produced by ci.ros2.org are created. 

To that end, we should install the not-strictly-necessary python3-colcon-bash package to ensure that a `setup.bash` script is present in the resulting archive, which aligns with the ci.ros2.org archives.