### PR TITLE
Drop explicit package installs in CI jobs

### DIFF
--- a/foxy/ci-benchmark.yaml
+++ b/foxy/ci-benchmark.yaml
@@ -16,8 +16,6 @@ build_tool_args: '--cmake-args -DAMENT_RUN_PERFORMANCE_TESTS=ON -DCMAKE_BUILD_TY
 build_tool_test_args: '--ctest-args -L performance --pytest-args -m performance'
 install_packages:
 - default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - maven  # for CycloneDDS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash

--- a/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -12,8 +12,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk  # for CycloneDDS
-- libssl-dev  # for Connext and CycloneDDS
-- libtinyxml2-dev  # for FastRTPS, even though disabled it is needed for the typesupport
 - maven  # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -10,9 +10,6 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
-install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_timeout: 300

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -8,9 +8,6 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
-install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_timeout: 300

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -11,8 +11,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - maven  # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -9,8 +9,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - maven  # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57

--- a/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -7,9 +7,6 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'  # even thought not used installed for the underlay
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
-install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_timeout: 300

--- a/foxy/ci-nightly-debug.yaml
+++ b/foxy/ci-nightly-debug.yaml
@@ -13,8 +13,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - maven  # for CycloneDDS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash

--- a/foxy/ci-nightly-extra-rmw-release.yaml
+++ b/foxy/ci-nightly-extra-rmw-release.yaml
@@ -13,8 +13,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - maven  # for CycloneDDS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash

--- a/foxy/ci-nightly-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-fastrtps-dynamic.yaml
@@ -10,8 +10,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/foxy/ci-nightly-fastrtps.yaml
+++ b/foxy/ci-nightly-fastrtps.yaml
@@ -10,8 +10,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/foxy/ci-nightly-performance.yaml
+++ b/foxy/ci-nightly-performance.yaml
@@ -16,8 +16,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 -DPERFORMANCE_TEST_CYCLONEDDS_ENABLED=1 -DPERFORMANCE_TEST_FASTRTPS_ENABLED=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - maven  # for CycloneDDS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash

--- a/foxy/ci-nightly-release.yaml
+++ b/foxy/ci-nightly-release.yaml
@@ -13,8 +13,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - maven  # for CycloneDDS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash

--- a/foxy/ci-overlay.yaml
+++ b/foxy/ci-overlay.yaml
@@ -12,8 +12,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 install_packages:
 - default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - maven  # for CycloneDDS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash

--- a/galactic/ci-benchmark.yaml
+++ b/galactic/ci-benchmark.yaml
@@ -15,8 +15,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DAMENT_RUN_PERFORMANCE_TESTS=ON -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 build_tool_test_args: '--ctest-args -L performance --pytest-args -m performance'
 install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/galactic/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/galactic/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -11,9 +11,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
-install_packages:
-- libssl-dev  # for Connext and CycloneDDS
-- libtinyxml2-dev  # for FastRTPS, even though disabled it is needed for the typesupport
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/galactic/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -11,9 +11,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
-install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/galactic/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -9,9 +9,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
-install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/galactic/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -10,9 +10,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
-install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/galactic/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -8,9 +8,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
-install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/galactic/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -8,9 +8,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
-install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-debug.yaml
+++ b/galactic/ci-nightly-debug.yaml
@@ -13,8 +13,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/galactic/ci-nightly-extra-rmw-release.yaml
+++ b/galactic/ci-nightly-extra-rmw-release.yaml
@@ -13,8 +13,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/galactic/ci-nightly-fastrtps-dynamic.yaml
+++ b/galactic/ci-nightly-fastrtps-dynamic.yaml
@@ -11,8 +11,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/galactic/ci-nightly-fastrtps.yaml
+++ b/galactic/ci-nightly-fastrtps.yaml
@@ -11,8 +11,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/galactic/ci-nightly-performance.yaml
+++ b/galactic/ci-nightly-performance.yaml
@@ -15,8 +15,6 @@ benchmark_schema: !include ../common/benchmark_schema.yaml
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 -DPERFORMANCE_TEST_CYCLONEDDS_ENABLED=1 -DPERFORMANCE_TEST_FASTRTPS_ENABLED=1 --no-warn-unused-cli'
 install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/galactic/ci-nightly-release.yaml
+++ b/galactic/ci-nightly-release.yaml
@@ -13,8 +13,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/galactic/ci-overlay.yaml
+++ b/galactic/ci-overlay.yaml
@@ -12,8 +12,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/rolling/ci-benchmark.yaml
+++ b/rolling/ci-benchmark.yaml
@@ -15,10 +15,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DAMENT_RUN_PERFORMANCE_TESTS=ON -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 build_tool_test_args: '--ctest-args -L performance --pytest-args -m performance'
 install_packages:
-- default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
-- maven  # for CycloneDDS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -11,11 +11,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
-install_packages:
-- default-jdk  # for CycloneDDS
-- libssl-dev  # for Connext and CycloneDDS
-- libtinyxml2-dev  # for FastRTPS, even though disabled it is needed for the typesupport
-- maven  # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -11,9 +11,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
-install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -9,9 +9,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
-install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -10,11 +10,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
-install_packages:
-- default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
-- maven  # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -8,11 +8,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
-install_packages:
-- default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
-- maven  # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -8,9 +8,6 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
-install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cyclonedds.yaml
+++ b/rolling/ci-nightly-cyclonedds.yaml
@@ -11,8 +11,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
-- default-jdk  # for CycloneDDS
-- maven  # for CycloneDDS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/rolling/ci-nightly-debug.yaml
+++ b/rolling/ci-nightly-debug.yaml
@@ -13,10 +13,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
-- default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
-- maven  # for CycloneDDS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/rolling/ci-nightly-extra-rmw-release.yaml
+++ b/rolling/ci-nightly-extra-rmw-release.yaml
@@ -13,10 +13,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
-- default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
-- maven  # for CycloneDDS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/rolling/ci-nightly-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-fastrtps-dynamic.yaml
@@ -11,8 +11,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/rolling/ci-nightly-fastrtps.yaml
+++ b/rolling/ci-nightly-fastrtps.yaml
@@ -11,8 +11,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/rolling/ci-nightly-performance.yaml
+++ b/rolling/ci-nightly-performance.yaml
@@ -15,10 +15,6 @@ benchmark_schema: !include ../common/benchmark_schema.yaml
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 -DPERFORMANCE_TEST_CYCLONEDDS_ENABLED=1 -DPERFORMANCE_TEST_FASTRTPS_ENABLED=1 --no-warn-unused-cli'
 install_packages:
-- default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
-- maven  # for CycloneDDS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/rolling/ci-nightly-release.yaml
+++ b/rolling/ci-nightly-release.yaml
@@ -13,10 +13,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
-- default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
-- maven  # for CycloneDDS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp

--- a/rolling/ci-overlay.yaml
+++ b/rolling/ci-overlay.yaml
@@ -12,10 +12,6 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
-- default-jdk  # for CycloneDDS
-- libasio-dev  # for FastRTPS
-- libtinyxml2-dev  # for FastRTPS
-- maven  # for CycloneDDS
 - ros-noetic-common-msgs
 - ros-noetic-rosbash
 - ros-noetic-roscpp


### PR DESCRIPTION
Both Fast-DDS and CycloneDDS provide package manifests in their upstream repositories now, which means that these explicit installs are no longer necessary because rosdep will take care of ensuring their installation.

The Foxy version of CycloneDDS was using the Java-based IDL compiler, which was opportunistically built if the dependencies were met, but they were not required. Therefore, Foxy still needs explicit installation of those dependencies.