### PR TITLE
Build only Fast-DDS in Rolling-on-Focal CI job

### DIFF
--- a/rolling/ci-rolling-on-focal.yaml
+++ b/rolling/ci-rolling-on-focal.yaml
@@ -13,7 +13,7 @@ jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * 6
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
-package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* --packages-up-to ros_base rviz2'
+package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.* --packages-up-to ros_base rviz2'
 repos_files:
 - https://github.com/ros2/ros2/raw/master/ros2.repos
 repositories:


### PR DESCRIPTION
This will substantially reduce the compute time spent testing because it will eliminate the cross-vendor tests.

It also drops us down to a single RMW implementation and disables runtime selection.