### PR TITLE
Add new drake-ros-underlay job for Rolling

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -64,6 +64,7 @@ distributions:
     ci_builds:
       benchmark: rolling/ci-benchmark.yaml
       clang-tidy: rolling/ci-clang-tidy.yaml
+      drake-ros-underlay: rolling/ci-drake-ros-underlay.yaml
       nightly-connext: rolling/ci-nightly-connext.yaml
       nightly-cross-vendor-connext-cyclonedds: rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
       nightly-cross-vendor-connext-fastrtps: rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml

--- a/rolling/ci-drake-ros-underlay.yaml
+++ b/rolling/ci-drake-ros-underlay.yaml
@@ -5,6 +5,7 @@ build_environment_variables:
   ROS_PYTHON_VERSION: '3'
 build_tool: colcon
 build_tool_args: '--merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
+# Add placeholder-with-space to deal with poor shell escaping in ros_buildfarm
 build_tool_test_args: '--merge-install --retest-until-pass 2 --ctest-args -LE "(linter|performance|xfail| placeholder-with-space )" --pytest-args -m "not linter and not performance and not xfail"'
 install_packages:
 - python3-colcon-bash
@@ -19,7 +20,7 @@ package_names:
 - cv_bridge
 - ros_base
 - rviz2
-package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.* .*iceoryx.*'
+package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*fastrtps.* .*fastcdr.* .*foonathan.*'
 repositories:
   keys:
   - |

--- a/rolling/ci-drake-ros-underlay.yaml
+++ b/rolling/ci-drake-ros-underlay.yaml
@@ -54,7 +54,7 @@ repositories:
     =i0tj
     -----END PGP PUBLIC KEY BLOCK-----
   urls:
-  - http://repo.ros2.org/ubuntu/main
+  - http://repo.ros2.org/ubuntu/testing
 targets:
   ubuntu:
     focal:

--- a/rolling/ci-drake-ros-underlay.yaml
+++ b/rolling/ci-drake-ros-underlay.yaml
@@ -1,0 +1,64 @@
+%YAML 1.1
+# ROS buildfarm ci-build file
+---
+build_environment_variables:
+  ROS_PYTHON_VERSION: '3'
+build_tool: colcon
+build_tool_args: '--merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
+build_tool_test_args: '--merge-install --retest-until-pass 2 --ctest-args -LE "(linter|performance|xfail| placeholder-with-space )" --pytest-args -m "not linter and not performance and not xfail"'
+install_packages:
+- python3-colcon-bash
+jenkins_job_label: ci-agent
+jenkins_job_priority: 50
+jenkins_job_schedule: 15 23 * * 6
+jenkins_job_timeout: 300
+jenkins_job_weight: 4
+package_dependencies: true
+package_names:
+- ament_cmake_clang_format
+- cv_bridge
+- ros_base
+- rviz2
+package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.* .*iceoryx.*'
+repositories:
+  keys:
+  - |
+    -----BEGIN PGP PUBLIC KEY BLOCK-----
+    Version: GnuPG v1
+
+    mQINBFzvJpYBEADY8l1YvO7iYW5gUESyzsTGnMvVUmlV3XarBaJz9bGRmgPXh7jc
+    VFrQhE0L/HV7LOfoLI9H2GWYyHBqN5ERBlcA8XxG3ZvX7t9nAZPQT2Xxe3GT3tro
+    u5oCR+SyHN9xPnUwDuqUSvJ2eqMYb9B/Hph3OmtjG30jSNq9kOF5bBTk1hOTGPH4
+    K/AY0jzT6OpHfXU6ytlFsI47ZKsnTUhipGsKucQ1CXlyirndZ3V3k70YaooZ55rG
+    aIoAWlx2H0J7sAHmqS29N9jV9mo135d+d+TdLBXI0PXtiHzE9IPaX+ctdSUrPnp+
+    TwR99lxglpIG6hLuvOMAaxiqFBB/Jf3XJ8OBakfS6nHrWH2WqQxRbiITl0irkQoz
+    pwNEF2Bv0+Jvs1UFEdVGz5a8xexQHst/RmKrtHLct3iOCvBNqoAQRbvWvBhPjO/p
+    V5cYeUljZ5wpHyFkaEViClaVWqa6PIsyLqmyjsruPCWlURLsQoQxABcL8bwxX7UT
+    hM6CtH6tGlYZ85RIzRifIm2oudzV5l+8oRgFr9yVcwyOFT6JCioqkwldW52P1pk/
+    /SnuexC6LYqqDuHUs5NnokzzpfS6QaWfTY5P5tz4KHJfsjDIktly3mKVfY0fSPVV
+    okdGpcUzvz2hq1fqjxB6MlB/1vtk0bImfcsoxBmF7H+4E9ZN1sX/tSb0KQARAQAB
+    tCZPcGVuIFJvYm90aWNzIDxpbmZvQG9zcmZvdW5kYXRpb24ub3JnPokCVAQTAQgA
+    PgIbAwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgBYhBMHPbjHmut6IaLFytPQu1vur
+    F8ZUBQJgsdhRBQkLTMW7AAoJEPQu1vurF8ZUTMwP/3f7EkOPIFjUdRmpNJ2db4iB
+    RQu5b2SJRG+KIdbvQBzKUBMV6/RUhEDPjhXZI3zDevzBewvAMKkqs2Q1cWo9WV7Z
+    PyTkvSyey/Tjn+PozcdvzkvrEjDMftIk8E1WzLGq7vnPLZ1q/b6Vq4H373Z+EDWa
+    DaDwW72CbCBLWAVtqff80CwlI2x8fYHKr3VBUnwcXNHR4+nRABfAWnaU4k+oTshC
+    Qucsd8vitNfsSXrKuKyz91IRHRPnJjx8UvGU4tRGfrHkw1505EZvgP02vXeRyWBR
+    fKiL1vGy4tCSRDdZO3ms2J2m08VPv65HsHaWYMnO+rNJmMZj9d9JdL/9GRf5F6U0
+    quoIFL39BhUEvBynuqlrqistnyOhw8W/IQy/ymNzBMcMz6rcMjMwhkgm/LNXoSD1
+    1OrJu4ktQwRhwvGVarnB8ihwjsTxZFylaLmFSfaA+OAlOqCLS1OkIVMzjW+Ul6A6
+    qjiCEUOsnlf4CGlhzNMZOx3low6ixzEqKOcfECpeIj80a2fBDmWkcAAjlHu6VBhA
+    TUDG9e2xKLzV2Z/DLYsb3+n9QW7KO0yZKfiuUo6AYboAioQKn5jh3iRvjGh2Ujpo
+    22G+oae3PcCc7G+z12j6xIY709FQuA49dA2YpzMda0/OX4LP56STEveDRrO+CnV6
+    WE+F5FaIKwb72PL4rLi4
+    =i0tj
+    -----END PGP PUBLIC KEY BLOCK-----
+  urls:
+  - http://repo.ros2.org/ubuntu/main
+targets:
+  ubuntu:
+    focal:
+      amd64:
+type: ci-build
+upload_directory: drake-ros-underlay
+version: 1


### PR DESCRIPTION
This job will build the underlay tarball for use with [drake-ros](https://github.com/RobotLocomotion/drake-ros/). It will continue to build against Ubuntu Focal even though Rolling has transitioned to Jammy.

This will replace the existing `rolling-on-focal` job, which has only successfully built once and will be removed in a follow-up PR.

Highlights:
* All package sources come from release repositories registered in the rosdistro index
* Only built RMW is ~~`rmw_fastrtps_cpp`~~ `rmw_cyclonedds_cpp` (until Fast-DDS stops segfaulting)
* Performance and linter tests are skipped
* Build schedule is weekly
* Tarball will be uploaded to repo.ros2.org

Currently, the scope includes `--packages-up-to`:
- ament_cmake_clang_format
- cv_bridge
- ros_base
- rviz2