### PR TITLE
Don't build ign_ros2_control for RHEL

### DIFF
--- a/galactic/release-rhel-build.yaml
+++ b/galactic/release-rhel-build.yaml
@@ -26,6 +26,7 @@ package_blacklist:
 - dwb_plugins  # lcov has no RPM package for RHEL 8
 - four_wheel_steering_msgs  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
+- ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL
 - io_context  # asio has no RPM package for RHEL 8
 - libmavconn  # asio has no RPM package for RHEL 8


### PR DESCRIPTION
This package is failing to build a source RPM.