### PR TITLE
In drake-ros-underlay, switch to Fast-DDS + add pycodestyle

### DIFF
--- a/rolling/ci-drake-ros-underlay.yaml
+++ b/rolling/ci-drake-ros-underlay.yaml
@@ -17,10 +17,11 @@ jenkins_job_weight: 4
 package_dependencies: true
 package_names:
 - ament_cmake_clang_format
+- ament_cmake_pycodestyle
 - cv_bridge
 - ros_base
 - rviz2
-package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*fastrtps.* .*fastcdr.* .*foonathan.*'
+package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclone.* .*iceoryx.*'
 repositories:
   keys:
   - |


### PR DESCRIPTION
As discussed in ROS 2 weekly meeting, it should be safe to switch back to Fast-DDS for this job.

Additionally, add `ament_cmake_pycodestyle` to the package list as it is a requirement of `drake-ros`.