### PR TITLE
Disable test_copyright tests in drake-ros-underlay

### DIFF
--- a/rolling/ci-drake-ros-underlay.yaml
+++ b/rolling/ci-drake-ros-underlay.yaml
@@ -6,7 +6,7 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--merge-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 # Add placeholder-with-space to deal with poor shell escaping in ros_buildfarm
-build_tool_test_args: '--merge-install --retest-until-pass 2 --ctest-args -LE "(linter|performance|xfail| placeholder-with-space )" --pytest-args -m "not linter and not performance and not xfail"'
+build_tool_test_args: '--merge-install --retest-until-pass 2 --ctest-args -LE "(linter|performance|xfail| placeholder-with-space )" --pytest-args -m "not linter and not performance and not xfail" -k "not test_copyright"'
 install_packages:
 - python3-colcon-bash
 jenkins_job_label: ci-agent


### PR DESCRIPTION
There are a few things at play here:
1. The copyright tests aren't consistently marked so that pytest can exclude them using a label, so they need to be called out by name.
2. We don't want to run these tests in this job anyway because they are a linter. If they were properly marked, we would be skipping them already.
3. The ament_copyright tool is misbehaving when a package which was previously a subdirectory is fetched as the repository root, as is the default behavior of rosinstall_generator. (filed upstream as ament/ament_lint#362)

This should take care of the last test failures we're seeing on this job: https://build.ros2.org/view/Rci/job/Rci__drake-ros-underlay_ubuntu_focal_amd64/6/testReport/