### PR TITLE
Switch drake-ros-underlay back to CycloneDDS

### DIFF
--- a/rolling/ci-drake-ros-underlay.yaml
+++ b/rolling/ci-drake-ros-underlay.yaml
@@ -21,7 +21,7 @@ package_names:
 - cv_bridge
 - ros_base
 - rviz2
-package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclone.* .*iceoryx.*'
+package_selection_args: '--packages-ignore-regex .*connext.* .*fastcdr.* .*fastrtps.* .*foonathan.*'
 repositories:
   keys:
   - |


### PR DESCRIPTION
It appears that rmw_fastrtps_cpp can no longer be built without introspection typesupport, meaning that there would always be multiple typesupport implementations available which will require a call to `dlopen`, which is not desirable.