### PR TITLE
Re-add libssl-dev to explicit packages for cross-vendor CI

### DIFF
--- a/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -12,6 +12,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk  # for CycloneDDS
+- libssl-dev  # for Fast-DDS security
 - maven  # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -10,6 +10,8 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_timeout: 300

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -8,6 +8,8 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_timeout: 300

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -11,6 +11,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk  # for CycloneDDS
+- libssl-dev  # for Fast-DDS security
 - maven  # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -9,6 +9,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - default-jdk  # for CycloneDDS
+- libssl-dev  # for Fast-DDS security
 - maven  # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57

--- a/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -7,6 +7,8 @@ build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'  # even thought not used installed for the underlay
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/galactic/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -11,6 +11,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/galactic/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -11,6 +11,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/galactic/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -9,6 +9,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/galactic/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -10,6 +10,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/galactic/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -8,6 +8,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/galactic/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -8,6 +8,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -11,6 +11,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -11,6 +11,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -9,6 +9,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -10,6 +10,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -8,6 +8,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -8,6 +8,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300


### PR DESCRIPTION
The upstream job of the cross-vendor CI jobs is the 'nightly-release' job, which includes the upstream ROS 1 packages explicitly so that the bridge can be built and tested. In the cross-vendor jobs, the ROS 1 packages are not installed because the bridge is not built or tested. One of the ROS 1 dependencies in the nightly-release jobs is pulling in libssl-dev as a dependency. Fast-DDS is detecting libssl-dev and using it to build security extensions automatically.

Because libssl-dev isn't a formal dependency of Fast-DDS and the ROS 1 packages aren't listed in the cross-vendor jobs, libssl-dev isn't getting installed and any attempts to link against Fast-DDS fail due to the absence.

An alternative to this change would be to explicitly disable security in Fast-DDS so that libssl-dev is not used even when it is present.