### PR TITLE
Specifically install tinyxml2 in cross-vendor CI

### DIFF
--- a/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -13,6 +13,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TEST
 install_packages:
 - default-jdk  # for CycloneDDS
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 - maven  # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -12,6 +12,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_timeout: 300

--- a/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -10,6 +10,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_timeout: 300

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -12,6 +12,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TEST
 install_packages:
 - default-jdk  # for CycloneDDS
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 - maven  # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57

--- a/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/foxy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -10,6 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TEST
 install_packages:
 - default-jdk  # for CycloneDDS
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 - maven  # for CycloneDDS
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57

--- a/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -9,6 +9,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TESTS=1 --no-warn-unused-cli'
 install_packages:
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/galactic/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -13,6 +13,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TEST
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/galactic/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -13,6 +13,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TEST
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/galactic/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -11,6 +11,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TEST
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/galactic/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -12,6 +12,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TEST
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/galactic/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -10,6 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TEST
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300

--- a/galactic/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/galactic/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -10,6 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_SINGLE_RMW_TEST
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 install_packages:
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
 jenkins_job_timeout: 300


### PR DESCRIPTION
Fast-DDS doesn't install its manifest, so the dependency from Fast-DDS on tinyxml2 is missed in these downstream jobs.

The dependency is listed in the colcon index, but the colcon index doesn't list the package type so we can't know that the dependencies could be consumed like rosdep keys. Fast-DDS isn't an ament package and therefore isn't in the ament index either.