### PR TITLE
Re-add libssl-dev to explicit packages for some Rolling CI

### DIFF
--- a/rolling/ci-benchmark.yaml
+++ b/rolling/ci-benchmark.yaml
@@ -11,6 +11,8 @@ benchmark_schema: !include ../common/benchmark_schema.yaml
 build_tool: colcon
 build_tool_args: '--cmake-args -DAMENT_RUN_PERFORMANCE_TESTS=ON -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 build_tool_test_args: '--ctest-args -L performance --pytest-args -m performance'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 240

--- a/rolling/ci-nightly-performance.yaml
+++ b/rolling/ci-nightly-performance.yaml
@@ -10,6 +10,8 @@ benchmark_patterns:
 benchmark_schema: !include ../common/benchmark_schema.yaml
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 -DPERFORMANCE_TEST_CYCLONEDDS_ENABLED=1 -DPERFORMANCE_TEST_FASTRTPS_ENABLED=1 --no-warn-unused-cli'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 180


### PR DESCRIPTION
Similar to other non-Rolling jobs, these jobs aren't picking up the implicit dependency on libssl-dev that Fast-DDS is opportunistically taking.