### PR TITLE
Fix the list_priorities script to work again.

### DIFF
--- a/list_priorities.py
+++ b/list_priorities.py
@@ -1,47 +1,48 @@
 #!/usr/bin/env python3
 
 import os
-import yaml
+import sys
 
+import yaml
+import yamlinclude
+
+
+DIRECTORIES = ['foxy', 'galactic', 'humble', 'rolling']
 
 def main():
-    priorities = get_priorities()
-    for key in sorted(priorities.keys()):
-        print(key)
-        for value in sorted(priorities[key]):
-            print(' ', value)
-
-
-def get_priorities():
-    priorities = {}
     base_path = os.path.dirname(__file__)
-    for root, dirs, files in os.walk(base_path):
-        # ignore folder starting with a dot
-        dirs[:] = [d for d in dirs if not d.startswith('.')]
-        dirs.sort()
+    priorities = {}
 
-        # ignore folder starting with a dot
+    for directory in DIRECTORIES:
+        current_path = os.path.join(base_path, directory)
+        yamlinclude.YamlIncludeConstructor.add_to_loader_class(loader_class=yaml.FullLoader, base_dir=current_path)
+
+        files = os.listdir(current_path)
         files[:] = [f for f in files if f.endswith('.yaml')]
         files.sort()
 
         for f in files:
-            path = os.path.join(root, f)
-            relpath = os.path.relpath(path, base_path)
-            collect_priorities(path, relpath, priorities)
-    return priorities
+            relpath = os.path.relpath(os.path.join(current_path, f), base_path)
+            with open(os.path.join(current_path, f)) as infp:
+                data = yaml.load(infp, Loader=yaml.FullLoader)
 
+            for key in sorted(data.keys()):
+                if not key.endswith('_priority'):
+                    continue
+                priority_value = data[key]
+                if priority_value not in priorities:
+                    priorities[priority_value] = set([])
+                priorities[priority_value].add(key + '::' + relpath)
 
-def collect_priorities(path, relpath, priorities):
-    with open(path, 'r') as h:
-        data = yaml.load(h)
-    for key in sorted(data.keys()):
-        if not key.endswith('_priority'):
-            continue
-        priority_value = data[key]
-        if priority_value not in priorities:
-            priorities[priority_value] = set([])
-        priorities[priority_value].add(key + '::' + relpath)
+        del yaml.FullLoader.yaml_constructors[yamlinclude.YamlIncludeConstructor.DEFAULT_TAG_NAME]
+
+    for key in sorted(priorities.keys()):
+       print(key)
+       for value in sorted(priorities[key]):
+           print(' ', value)
+
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())


### PR DESCRIPTION
In particular, we needed to make sure that we support !include
in YAML, which is new since the last time this script was
touched (in 2016!).  Along with that, revamp the whole
structure of it, since we now have to be more careful about
directories.  And finally, make it very specifically look at
particular directories, since nowadays not all directories
contain jenkins config scripts.

With these changes, it can now be used again to list out the
priorities.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>