### PR TITLE
Use index.yaml to generate directory index in list_priorities.

### DIFF
--- a/list_priorities.py
+++ b/list_priorities.py
@@ -17,9 +17,7 @@ def main():
     with open(os.path.join(base_path, 'index.yaml')) as infp:
         index_data = yaml.load(infp, Loader=yaml.FullLoader)
 
-    directories = []
-    for distro in index_data['distributions'].keys():
-        directories.append(distro)
+    directories = list(index_data['distributions'].keys())
 
     del yaml.FullLoader.yaml_constructors[yamlinclude.YamlIncludeConstructor.DEFAULT_TAG_NAME]
 

--- a/list_priorities.py
+++ b/list_priorities.py
@@ -7,13 +7,25 @@ import yaml
 import yamlinclude
 
 
-DIRECTORIES = ['foxy', 'galactic', 'humble', 'rolling']
-
 def main():
     base_path = os.path.dirname(__file__)
+
+    # First parse the index.yaml to find the list of distributions that we
+    # should parse.
+
+    yamlinclude.YamlIncludeConstructor.add_to_loader_class(loader_class=yaml.FullLoader, base_dir=base_path)
+    with open(os.path.join(base_path, 'index.yaml')) as infp:
+        index_data = yaml.load(infp, Loader=yaml.FullLoader)
+
+    directories = []
+    for distro in index_data['distributions'].keys():
+        directories.append(distro)
+
+    del yaml.FullLoader.yaml_constructors[yamlinclude.YamlIncludeConstructor.DEFAULT_TAG_NAME]
+
     priorities = {}
 
-    for directory in DIRECTORIES:
+    for directory in directories:
         current_path = os.path.join(base_path, directory)
         yamlinclude.YamlIncludeConstructor.add_to_loader_class(loader_class=yaml.FullLoader, base_dir=current_path)
 


### PR DESCRIPTION
As suggested by Steven!, we should parse the index.yaml to
find the list of distributions to parse, rather than having
a hard-coded list.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>