### PR TITLE
Specifically install tinyxml2 in performance CI

### DIFF
--- a/humble/ci-nightly-performance.yaml
+++ b/humble/ci-nightly-performance.yaml
@@ -12,6 +12,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 -DPERFORMANCE_TEST_CYCLONEDDS_ENABLED=1 -DPERFORMANCE_TEST_FASTRTPS_ENABLED=1 --no-warn-unused-cli'
 install_packages:
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
 jenkins_job_timeout: 180

--- a/rolling/ci-nightly-performance.yaml
+++ b/rolling/ci-nightly-performance.yaml
@@ -12,6 +12,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 -DPERFORMANCE_TEST_CYCLONEDDS_ENABLED=1 -DPERFORMANCE_TEST_FASTRTPS_ENABLED=1 --no-warn-unused-cli'
 install_packages:
 - libssl-dev  # for Fast-DDS security
+- libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 180


### PR DESCRIPTION
Should address the current build failure on performance jobs for Humble and Rolling: https://github.com/ros2/performance_test/issues/39#issuecomment-1124288990

See this PR for justification: https://github.com/ros2/ros_buildfarm_config/pull/227

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>