### PR TITLE
Add failing packages to build blacklists on Rolling and Humble.

### DIFF
--- a/humble/release-build.yaml
+++ b/humble/release-build.yaml
@@ -15,6 +15,10 @@ notifications:
   - audrow+build.ros2.org@openrobotics.org
   - ros2-buildfarm-humble@googlegroups.com
   maintainers: true
+package_blacklist:
+- swri_console_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
+- swri_geometry_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
+- swri_roscpp  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
 sync:
   package_count: 499
   packages: [desktop]

--- a/humble/release-rhel-build.yaml
+++ b/humble/release-rhel-build.yaml
@@ -48,6 +48,10 @@ package_blacklist:
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
 - sdformat_test_files  # sdformat has no RPM packages for RHEL 8
 - sdformat_urdf  # sdformat has no RPM packages for RHEL 8
+- swri_console_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
+- swri_geometry_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
+- swri_prefix_tools  # Fix is merged but unreleased. https://github.com/swri-robotics/marti_common/pull/665
+- swri_roscpp  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
 - ublox_gps  # asio has no RPM package for RHEL 8
 - usb_cam  # ffmpeg has no RPM package for RHEL

--- a/humble/release-ubuntu-arm64-build.yaml
+++ b/humble/release-ubuntu-arm64-build.yaml
@@ -15,6 +15,10 @@ notifications:
 sync:
   package_count: 499
   packages: [desktop]
+package_blacklist:
+- swri_console_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
+- swri_geometry_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
+- swri_roscpp  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
 repositories:
   keys:
   - |

--- a/rolling/release-build.yaml
+++ b/rolling/release-build.yaml
@@ -15,6 +15,10 @@ notifications:
   - steven+build.ros2.org@openrobotics.org
   - ros2-buildfarm-rolling@googlegroups.com
   maintainers: true
+package_blacklist:
+- swri_console_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
+- swri_geometry_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
+- swri_roscpp  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
 sync:
   package_count: 499
   packages: [desktop]

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -48,6 +48,10 @@ package_blacklist:
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
 - sdformat_test_files  # sdformat has no RPM packages for RHEL 8
 - sdformat_urdf  # sdformat has no RPM packages for RHEL 8
+- swri_console_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
+- swri_geometry_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
+- swri_prefix_tools  # Fix is merged but unreleased. https://github.com/swri-robotics/marti_common/pull/665
+- swri_roscpp  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
 - ublox_gps  # asio has no RPM package for RHEL 8
 - usb_cam  # ffmpeg has no RPM package for RHEL

--- a/rolling/release-ubuntu-arm64-build.yaml
+++ b/rolling/release-ubuntu-arm64-build.yaml
@@ -12,6 +12,10 @@ notifications:
   - steven+build.ros2.org@openrobotics.org
   - ros2-buildfarm-rolling@googlegroups.com
   maintainers: true
+package_blacklist:
+- swri_console_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
+- swri_geometry_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
+- swri_roscpp  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
 sync:
   package_count: 499
   packages: [desktop]


### PR DESCRIPTION
These packages are failing to build on Rolling Ubuntu amd64
- [swri_console_util](https://build.ros2.org/job/Rbin_uJ64__swri_console_util__ubuntu_jammy_amd64__binary)
- [swri_geometry_util](https://build.ros2.org/job/Rbin_uJ64__swri_geometry_util__ubuntu_jammy_amd64__binary)
- [swri_prefix_tools](https://build.ros2.org/job/Rbin_uJ64__swri_prefix_tools__ubuntu_jammy_amd64__binary)
- [swri_roscpp](https://build.ros2.org/job/Rbin_uJ64__swri_roscpp__ubuntu_jammy_amd64__binary)

These packages are failing to build on Rolling RHEL 8 x86_64
- [swri_console_util](https://build.ros2.org/job/Rbin_rhel_el864__swri_console_util__rhel_8_x86_64__binary)
- [swri_geometry_util](https://build.ros2.org/job/Rbin_rhel_el864__swri_geometry_util__rhel_8_x86_64__binary)
- [swri_prefix_tools](https://build.ros2.org/job/Rbin_rhel_el864__swri_prefix_tools__rhel_8_x86_64__binary)
- [swri_roscpp](https://build.ros2.org/job/Rbin_rhel_el864__swri_roscpp__rhel_8_x86_64__binary)

And on Humble Ubuntu amd64
- [swri_console_util](https://build.ros2.org/job/Hbin_uJ64__swri_console_util__ubuntu_jammy_amd64__binary)
- [swri_geometry_util](https://build.ros2.org/job/Hbin_uJ64__swri_geometry_util__ubuntu_jammy_amd64__binary)
- [swri_prefix_tools](https://build.ros2.org/job/Hbin_uJ64__swri_prefix_tools__ubuntu_jammy_amd64__binary)
- [swri_roscpp](https://build.ros2.org/job/Hbin_uJ64__swri_roscpp__ubuntu_jammy_amd64__binary)

And Humble RHEL 8
- [swri_console_util](https://build.ros2.org/job/Hbin_rhel_el864__swri_console_util__rhel_8_x86_64__binary)
- [swri_geometry_util](https://build.ros2.org/job/Hbin_rhel_el864__swri_geometry_util__rhel_8_x86_64__binary)
- [swri_prefix_tools](https://build.ros2.org/job/Hbin_rhel_el864__swri_prefix_tools__rhel_8_x86_64__binary)
- [swri_roscpp](https://build.ros2.org/job/Hbin_rhel_el864__swri_roscpp__rhel_8_x86_64__binary)

Normally for packages which are failing to build globally the first
thing I would do is remove the package from the release list in the
distribution files. That approach has the advantage of allowing a simple
re-release to trigger a new attempt to build the blocked packages.
However, when using that approach downstream jobs are not detected and
blocked along with the blacklisted job which means that packages which
depend on "dropped" releases will just start failing with an error
installing the dropped package.

I've come around to the idea that it's better for the build farm overall
if packages are blocked via build configuration unless the entire
release is broken and should be removed.