### PR TITLE
Add ouster_msgs to excluded packages on Rolling and Humble.

### DIFF
--- a/humble/release-rhel-build.yaml
+++ b/humble/release-rhel-build.yaml
@@ -37,6 +37,7 @@ package_blacklist:
 - octomap_server  # Build failures on RHEL
 - octovis  # Build failures on RHEL
 - ompl  # opende has no RPM package for RHEL
+- ouster_msgs  # libtins-dev has no RPM package for RHEL (dependency of sibling package ros2_ouster)
 - ros2_ouster  # libtins-dev has no RPM package for RHEL
 - rmf_demos_maps  # Build failures on RHEL https://github.com/open-rmf/rmf_demos/issues/119
 - rmf_robot_sim_common  # Build failures on RHEL https://github.com/open-rmf/rmf_simulation/issues/67

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -37,6 +37,7 @@ package_blacklist:
 - octomap_server  # Build failures on RHEL
 - octovis  # Build failures on RHEL
 - ompl  # opende has no RPM package for RHEL
+- ouster_msgs  # libtins-dev has no RPM package for RHEL (dependency of sibling package ros2_ouster)
 - ros2_ouster  # libtins-dev has no RPM package for RHEL
 - rmf_demos_maps  # Build failures on RHEL https://github.com/open-rmf/rmf_demos/issues/119
 - rmf_robot_sim_common  # Build failures on RHEL https://github.com/open-rmf/rmf_simulation/issues/67


### PR DESCRIPTION
This is a followup to #236 and #237.
Although this package does not directly or indirectly depend on
libtins-dev, when bloom fails to resolve rosdep keys for the sibling
package ros2_ouster it drops all release metadata for the platform in
that repository regardless of individual package.

As a result the sourcepkg job for RHEL fails since the expected tags are
missing in the bloom repository.

It is possible that a future enhancement to bloom could process sibling
packages individually and allow ouster_msgs to continue building in this
situation but for now the only way to get ouster_msgs building on RHEL
would be to split it out into its own repository.

Humble sourcepkg job: https://build.ros2.org/job/Hsrc_el8__ouster_msgs__rhel_8__source/
Rolling sourcepkg job: https://build.ros2.org/job/Rsrc_el8__ouster_msgs__rhel_8__source/