### PR TITLE
Update credentials used for uploaded RPM packages

### DIFF
--- a/galactic/release-rhel-build.yaml
+++ b/galactic/release-rhel-build.yaml
@@ -165,5 +165,7 @@ targets:
       x86_64:
 type: release-build
 upload_credential_id: jenkins-agent
-upload_destination_credential_id: upload_host
+upload_credential_id_pulp: pulp_admin
+upload_destination_credential_id: pulp_base_url
+upload_host: repo.ros2.org
 version: 2

--- a/galactic/release-rhel-build.yaml
+++ b/galactic/release-rhel-build.yaml
@@ -164,6 +164,6 @@ targets:
     '8':
       x86_64:
 type: release-build
-upload_credential_id: pulp_admin
-upload_destination_credential_id: pulp_base_url
+upload_credential_id: jenkins-agent
+upload_destination_credential_id: upload_host
 version: 2

--- a/humble/release-rhel-build.yaml
+++ b/humble/release-rhel-build.yaml
@@ -132,6 +132,6 @@ targets:
     '8':
       x86_64:
 type: release-build
-upload_credential_id: pulp_admin
-upload_destination_credential_id: pulp_base_url
+upload_credential_id: jenkins-agent
+upload_destination_credential_id: upload_host
 version: 2

--- a/humble/release-rhel-build.yaml
+++ b/humble/release-rhel-build.yaml
@@ -133,5 +133,7 @@ targets:
       x86_64:
 type: release-build
 upload_credential_id: jenkins-agent
-upload_destination_credential_id: upload_host
+upload_credential_id_pulp: pulp_admin
+upload_destination_credential_id: pulp_base_url
+upload_host: repo.ros2.org
 version: 2

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -131,6 +131,6 @@ targets:
     '8':
       x86_64:
 type: release-build
-upload_credential_id: pulp_admin
-upload_destination_credential_id: pulp_base_url
+upload_credential_id: jenkins-agent
+upload_destination_credential_id: upload_host
 version: 2

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -132,5 +132,7 @@ targets:
       x86_64:
 type: release-build
 upload_credential_id: jenkins-agent
-upload_destination_credential_id: upload_host
+upload_credential_id_pulp: pulp_admin
+upload_destination_credential_id: pulp_base_url
+upload_host: repo.ros2.org
 version: 2


### PR DESCRIPTION
This update switches the main upload credential to the `jenkins-agent` ssh credential to allow the agent jenkins jobs to communicate with the repo host via ssh.

In order to maintain pulp operation during the transition to createrepo-agent, add extra fields for the pulp-specific credentials.