### PR TITLE
Synchronize drake-ros-underlay package lists among distros

### DIFF
--- a/rolling/ci-drake-ros-underlay.yaml
+++ b/rolling/ci-drake-ros-underlay.yaml
@@ -16,11 +16,14 @@ jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_dependencies: true
 package_names:
+- action_msgs
 - ament_cmake_clang_format
 - ament_cmake_pycodestyle
 - cv_bridge
 - ros_base
 - rviz2
+- unique_identifier_msgs
+- xacro
 package_selection_args: '--packages-ignore-regex .*connext.* .*fastcdr.* .*fastrtps.* .*foonathan.*'
 repositories:
   keys:


### PR DESCRIPTION
Aligns the Rolling job with Humble.

Related to #249 and #247