### PR TITLE
Update RHEL build exclusion lists

### DIFF
--- a/galactic/release-rhel-build.yaml
+++ b/galactic/release-rhel-build.yaml
@@ -35,6 +35,7 @@ package_blacklist:
 - moveit_configs_utils  # libogre-dev has no RPM package for RHEL
 - moveit_resources_prbt_support  # libogre-dev has no RPM package for RHEL
 - mrpt2  # ffmpeg has no RPM package in supported repositories
+- mrt_cmake_modules  # Not yet generated for RHEL
 - ntpd_driver  # libpoco-dev has no RPM package for RHEL 8
 - ompl  # opende has no RPM package for RHEL
 - popf  # COIN-OR packages have no RPM packages for RHEL 8

--- a/humble/release-rhel-build.yaml
+++ b/humble/release-rhel-build.yaml
@@ -39,14 +39,21 @@ package_blacklist:
 - popf  # COIN-OR packages have no RPM packages for RHEL 8
 - rcgcd_spl_14  # python3-construct has no RPM for RHEL 8
 - rcgcrd_spl_4  # python3-construct has no RPM for RHEL 8
-- rmf_demos_maps  # Build failures on RHEL https://github.com/open-rmf/rmf_demos/issues/119
-- rmf_robot_sim_common  # Build failures on RHEL https://github.com/open-rmf/rmf_simulation/issues/67
-- rmf_robot_sim_ignition_plugins  # ignition has no RPM packages for RHEL
+- rmf_building_map_tools  # ignition has no RPM packages for RHEL
+- rmf_demos_assets  # ignition has no RPM packages for RHEL
+- rmf_demos_dashboard_resources  # ignition has no RPM packages for RHEL
+- rmf_demos_maps  # ignition has no RPM packages for RHEL
+- rmf_demos_panel  # ignition has no RPM packages for RHEL
+- rmf_demos_tasks  # ignition has no RPM packages for RHEL
+- rmf_robot_sim_common  # ignition has no RPM packages for RHEL
+- rmf_traffic_editor  # ignition has no RPM packages for RHEL
+- rmf_traffic_editor_assets  # ignition has no RPM packages for RHEL
 - rmf_traffic_ros2  # Build failures on RHEl https://github.com/open-rmf/rmf_ros2/issues/156
 - ros_gz_bridge  # gazebo has no RPM packages for RHEL
-- ros_gz_gazebo  # gazebo has no RPM packages for RHEL
 - ros_gz_interfaces  # gazebo has no RPM packages for RHEL
+- ros_gz_sim  # gazebo has no RPM packages for RHEL
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
+- rsl  # Not yet generated for RHEL
 - sdformat_test_files  # sdformat has no RPM packages for RHEL 8
 - sdformat_urdf  # sdformat has no RPM packages for RHEL 8
 - slider_publisher  # Not yet generated for RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -37,14 +37,22 @@ package_blacklist:
 - ouster_msgs  # libtins-dev has no RPM package for RHEL
 - rcgcd_spl_14  # python3-construct has no RPM for RHEL 8
 - rcgcrd_spl_4  # python3-construct has no RPM for RHEL 8
-- rmf_demos_maps  # Build failures on RHEL https://github.com/open-rmf/rmf_demos/issues/119
-- rmf_robot_sim_common  # Build failures on RHEL https://github.com/open-rmf/rmf_simulation/issues/67
-- rmf_robot_sim_ignition_plugins  # ignition has no RPM packages for RHEL
+- rmf_building_map_tools  # ignition has no RPM packages for RHEL
+- rmf_building_sim_common  # ignition has no RPM packages for RHEL
+- rmf_demos_assets  # ignition has no RPM packages for RHEL
+- rmf_demos_dashboard_resources  # ignition has no RPM packages for RHEL
+- rmf_demos_maps  # ignition has no RPM packages for RHEL
+- rmf_demos_panel  # ignition has no RPM packages for RHEL
+- rmf_demos_tasks  # ignition has no RPM packages for RHEL
+- rmf_robot_sim_common  # ignition has no RPM packages for RHEL
+- rmf_traffic_editor  # ignition has no RPM packages for RHEL
+- rmf_traffic_editor_assets  # ignition has no RPM packages for RHEL
 - rmf_traffic_ros2  # Build failures on RHEl https://github.com/open-rmf/rmf_ros2/issues/156
 - ros_ign_bridge  # ignition has no RPM packages for RHEL
 - ros_ign_gazebo  # ignition has no RPM packages for RHEL
 - ros_ign_interfaces  # ignition has no RPM packages for RHEL
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
+- rsl  # Not yet generated for RHEL
 - splsm_7  # python3-construct has no RPM package for RHEL 8
 - sdformat_test_files  # sdformat has no RPM packages for RHEL 8
 - sdformat_urdf  # sdformat has no RPM packages for RHEL 8


### PR DESCRIPTION
Lots of new RMF packages can't be built because there are Ignition packages in the same repository.