### PR TITLE
Add webots_ros2_drivers to packages that don't build on ARM64.

### DIFF
--- a/rolling/release-ubuntu-arm64-build.yaml
+++ b/rolling/release-ubuntu-arm64-build.yaml
@@ -16,6 +16,7 @@ package_blacklist:
 - swri_console_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
 - swri_geometry_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
 - swri_roscpp  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
+- webots_ros2_driver  # ARM64 not supported by dependencies https://github.com/cyberbotics/webots_ros2/issues/522
 sync:
   package_count: 499
   packages: [desktop]


### PR DESCRIPTION
Following up on the issue reported in https://github.com/cyberbotics/webots_ros2/issues/522

This change can be reverted when AMR64 support is available.