### PR TITLE
Remove webots_ros2_driver from blacklist

### DIFF
--- a/rolling/release-ubuntu-arm64-build.yaml
+++ b/rolling/release-ubuntu-arm64-build.yaml
@@ -16,7 +16,6 @@ package_blacklist:
 - swri_console_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
 - swri_geometry_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
 - swri_roscpp  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
-- webots_ros2_driver  # ARM64 not supported by dependencies https://github.com/cyberbotics/webots_ros2/issues/522
 sync:
   package_count: 499
   packages: [desktop]


### PR DESCRIPTION
Revert the changes of #256. `webots_ros2_driver` compiles on ARM64 in the new version (`2023.0.0`).