### PR TITLE
Stop automated builds for Galactic

### DIFF
--- a/galactic/ci-nightly-connext.yaml
+++ b/galactic/ci-nightly-connext.yaml
@@ -23,7 +23,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
-jenkins_job_schedule: 15 23 3-30/3 * *
+# jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rosbag2_converter_default_plugins --packages-ignore-regex .*cyclonedds.* rmw_fastrtps.*'

--- a/galactic/ci-nightly-cyclonedds.yaml
+++ b/galactic/ci-nightly-cyclonedds.yaml
@@ -21,7 +21,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
-jenkins_job_schedule: 15 23 3-30/3 * *
+# jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*fastrtps.*'

--- a/galactic/ci-nightly-debug.yaml
+++ b/galactic/ci-nightly-debug.yaml
@@ -23,7 +23,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
-jenkins_job_schedule: 15 23 3-30/3 * *
+# jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/galactic/ci-nightly-extra-rmw-release.yaml
+++ b/galactic/ci-nightly-extra-rmw-release.yaml
@@ -23,7 +23,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
-jenkins_job_schedule: 15 23 3-30/3 * *
+# jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 repos_files:

--- a/galactic/ci-nightly-fastrtps-dynamic.yaml
+++ b/galactic/ci-nightly-fastrtps-dynamic.yaml
@@ -21,7 +21,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
-jenkins_job_schedule: 15 23 3-30/3 * *
+# jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.*'

--- a/galactic/ci-nightly-fastrtps.yaml
+++ b/galactic/ci-nightly-fastrtps.yaml
@@ -21,7 +21,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
-jenkins_job_schedule: 15 23 3-30/3 * *
+# jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.*'

--- a/galactic/ci-nightly-release.yaml
+++ b/galactic/ci-nightly-release.yaml
@@ -23,7 +23,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 56
-jenkins_job_schedule: 15 23 3-30/3 * *
+# jenkins_job_schedule: 15 23 3-30/3 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/galactic/release-build.yaml
+++ b/galactic/release-build.yaml
@@ -15,6 +15,8 @@ notifications:
   - scott+build.ros2.org@openrobotics.org
   - ros2-buildfarm-galactic@googlegroups.com
   maintainers: true
+package_whitelist:
+- null
 sync:
   package_count: 262
 repositories:

--- a/galactic/release-focal-arm64-build.yaml
+++ b/galactic/release-focal-arm64-build.yaml
@@ -12,6 +12,8 @@ notifications:
   - scott+build.ros2.org@openrobotics.org
   - ros2-buildfarm-galactic@googlegroups.com
   maintainers: true
+package_whitelist:
+- null
 sync:
   package_count: 262
 repositories:

--- a/galactic/release-rhel-build.yaml
+++ b/galactic/release-rhel-build.yaml
@@ -14,6 +14,8 @@ notifications:
   emails:
   - scott+build.ros2.org@openrobotics.org
   maintainers: false
+package_whitelist:
+- null
 package_blacklist:
 - acado_vendor  # Requires unreleased changes
 - ament_black  # black has no RPM packages for RHEL


### PR DESCRIPTION
This change should stop Galactic builds from being triggered automatically while we wait for the dust to settle. Once we're certain that we won't need the jobs anymore, we can delete them.