### PR TITLE
Upload nightly-cyclonedds artifacts to repo.ros2.org

### DIFF
--- a/humble/ci-nightly-cyclonedds.yaml
+++ b/humble/ci-nightly-cyclonedds.yaml
@@ -54,4 +54,5 @@ targets:
     jammy:
       amd64:
 type: ci-build
+upload_directory: nightly-cyclonedds
 version: 1

--- a/rolling/ci-nightly-cyclonedds.yaml
+++ b/rolling/ci-nightly-cyclonedds.yaml
@@ -54,4 +54,5 @@ targets:
     jammy:
       amd64:
 type: ci-build
+upload_directory: nightly-cyclonedds
 version: 1


### PR DESCRIPTION
Rather than standing up a bespoke job for the drake-ros-underlay on supported Ubuntu versions, we can just upload the results of the existing jobs which already produce an adequate artifact.