### PR TITLE
Change alternating days from 3->2 for Foxy and Humble nightlies

### DIFF
--- a/foxy/ci-nightly-connext.yaml
+++ b/foxy/ci-nightly-connext.yaml
@@ -22,7 +22,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
-jenkins_job_schedule: 15 23 1-31/3 * *
+jenkins_job_schedule: 15 23 1-31/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*cyclonedds.* .*fastrtps.*'

--- a/foxy/ci-nightly-cyclonedds.yaml
+++ b/foxy/ci-nightly-cyclonedds.yaml
@@ -22,7 +22,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
-jenkins_job_schedule: 15 23 1-31/3 * *
+jenkins_job_schedule: 15 23 1-31/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*fastrtps.*'

--- a/foxy/ci-nightly-debug.yaml
+++ b/foxy/ci-nightly-debug.yaml
@@ -24,7 +24,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
-jenkins_job_schedule: 15 23 1-31/3 * *
+jenkins_job_schedule: 15 23 1-31/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/foxy/ci-nightly-fastrtps-dynamic.yaml
+++ b/foxy/ci-nightly-fastrtps-dynamic.yaml
@@ -20,7 +20,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
-jenkins_job_schedule: 15 23 1-31/3 * *
+jenkins_job_schedule: 15 23 1-31/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.*'

--- a/foxy/ci-nightly-fastrtps.yaml
+++ b/foxy/ci-nightly-fastrtps.yaml
@@ -20,7 +20,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
-jenkins_job_schedule: 15 23 1-31/3 * *
+jenkins_job_schedule: 15 23 1-31/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.*'

--- a/foxy/ci-nightly-release.yaml
+++ b/foxy/ci-nightly-release.yaml
@@ -24,7 +24,7 @@ install_packages:
 - ros-noetic-tf2-msgs
 jenkins_job_label: ci-agent
 jenkins_job_priority: 57
-jenkins_job_schedule: 15 23 1-31/3 * *
+jenkins_job_schedule: 15 23 1-31/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/humble/ci-nightly-connext.yaml
+++ b/humble/ci-nightly-connext.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/2 * *
+jenkins_job_schedule: 15 23 2-30/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rosbag2_converter_default_plugins --packages-ignore-regex .*cyclonedds.* rmw_fastrtps.*'

--- a/humble/ci-nightly-connext.yaml
+++ b/humble/ci-nightly-connext.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/3 * *
+jenkins_job_schedule: 15 23 2-29/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rosbag2_converter_default_plugins --packages-ignore-regex .*cyclonedds.* rmw_fastrtps.*'

--- a/humble/ci-nightly-cyclonedds.yaml
+++ b/humble/ci-nightly-cyclonedds.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/3 * *
+jenkins_job_schedule: 15 23 2-29/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*fastrtps.*'

--- a/humble/ci-nightly-cyclonedds.yaml
+++ b/humble/ci-nightly-cyclonedds.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/2 * *
+jenkins_job_schedule: 15 23 2-30/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*fastrtps.*'

--- a/humble/ci-nightly-debug.yaml
+++ b/humble/ci-nightly-debug.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/2 * *
+jenkins_job_schedule: 15 23 2-30/2 * *
 jenkins_job_timeout: 360
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/humble/ci-nightly-debug.yaml
+++ b/humble/ci-nightly-debug.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/3 * *
+jenkins_job_schedule: 15 23 2-29/2 * *
 jenkins_job_timeout: 360
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/humble/ci-nightly-fastrtps-dynamic.yaml
+++ b/humble/ci-nightly-fastrtps-dynamic.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/3 * *
+jenkins_job_schedule: 15 23 2-29/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.*'

--- a/humble/ci-nightly-fastrtps-dynamic.yaml
+++ b/humble/ci-nightly-fastrtps-dynamic.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/2 * *
+jenkins_job_schedule: 15 23 2-30/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.*'

--- a/humble/ci-nightly-fastrtps.yaml
+++ b/humble/ci-nightly-fastrtps.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/3 * *
+jenkins_job_schedule: 15 23 2-29/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.*'

--- a/humble/ci-nightly-fastrtps.yaml
+++ b/humble/ci-nightly-fastrtps.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/2 * *
+jenkins_job_schedule: 15 23 2-30/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.*'

--- a/humble/ci-nightly-release.yaml
+++ b/humble/ci-nightly-release.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/3 * *
+jenkins_job_schedule: 15 23 2-29/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/humble/ci-nightly-release.yaml
+++ b/humble/ci-nightly-release.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/2 * *
+jenkins_job_schedule: 15 23 2-30/2 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

We were running Foxy, Galactic and Humble nightlies on alternating days since https://github.com/ros2/ros_buildfarm_config/pull/112. Now that Galactic is EOL, Foxy and Humble nightlies still run each 3 days.

This PR spreads the load of CI jobs between Foxy and Humble, so they run each 2 days.