### PR TITLE
Remove rosbag2_converter_default_plugins from nightly CI jobs.

### DIFF
--- a/rolling/ci-nightly-connext.yaml
+++ b/rolling/ci-nightly-connext.yaml
@@ -13,7 +13,7 @@ jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
-package_selection_args: '--packages-ignore rosbag2_converter_default_plugins --packages-ignore-regex .*cyclonedds.* rmw_fastrtps.*'
+package_selection_args: '--packages-ignore-regex .*cyclonedds.* rmw_fastrtps.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/rolling/ros2.repos
 repositories:

--- a/rolling/ci-nightly-cyclonedds.yaml
+++ b/rolling/ci-nightly-cyclonedds.yaml
@@ -11,7 +11,7 @@ jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
-package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*fastrtps.*'
+package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor --packages-ignore-regex .*connext.* .*fastrtps.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/rolling/ros2.repos
 repositories:

--- a/rolling/ci-nightly-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-fastrtps-dynamic.yaml
@@ -11,7 +11,7 @@ jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
-package_selection_args: '--packages-ignore rmw_fastrtps_cpp rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.*'
+package_selection_args: '--packages-ignore rmw_fastrtps_cpp --packages-ignore-regex .*connext.* .*cyclonedds.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/rolling/ros2.repos
 repositories:


### PR DESCRIPTION
That package was removed quite a while ago, and this avoids a warning in the jobs.

Signed-off-by: Chris Lalancette <clalancette@gmail.com>