### PR TITLE
openni2_camera cannot build on RHEL

### DIFF
--- a/humble/release-rhel-build.yaml
+++ b/humble/release-rhel-build.yaml
@@ -35,6 +35,7 @@ package_blacklist:
 - octovis  # Build failures on RHEL
 - ompl  # opende has no RPM package for RHEL
 - open3d_conversions  # open3d has no RPM package for RHEL
+- openni2_camera  # libopenni2-dev does not exist on RHEL
 - ouster_msgs  # libtins-dev has no RPM package for RHEL
 - popf  # COIN-OR packages have no RPM packages for RHEL 8
 - rcgcd_spl_14  # python3-construct has no RPM for RHEL 8

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -34,6 +34,7 @@ package_blacklist:
 - octovis  # Build failures on RHEL
 - ompl  # opende has no RPM package for RHEL
 - open3d_conversions  # open3d has no RPM package for RHEL
+- openni2_camera  # libopenni2-dev does not exist on RHEL
 - ouster_msgs  # libtins-dev has no RPM package for RHEL
 - rcgcd_spl_14  # python3-construct has no RPM for RHEL 8
 - rcgcrd_spl_4  # python3-construct has no RPM for RHEL 8


### PR DESCRIPTION
The primary underlying dependency (libopenni2-dev) is unavailable on RHEL, so this build will never succeed