### PR TITLE
Remove urdfdom_py from the Iron and Rolling blacklist.

### DIFF
--- a/iron/release-rhel-build.yaml
+++ b/iron/release-rhel-build.yaml
@@ -71,7 +71,6 @@ package_blacklist:
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
 - tvm_vendor  # Build failures on AlmaLinux (but not RHEL)
 - ur_dashboard_msgs  # docker.io has no RPM packages for RHEL
-- urdfdom_py  # Build failures on RHEL https://github.com/ros/urdf_parser_py/pull/78
 - usb_cam  # ffmpeg has no RPM package for RHEL
 - vrpn_mocap  # Requires unreleased changes: https://github.com/vrpn/vrpn/pull/278
 - warehouse_ros_mongo  # mongodb has no RPM package for RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -73,7 +73,6 @@ package_blacklist:
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
 - tvm_vendor  # Build failures on AlmaLinux (but not RHEL)
 - ur_dashboard_msgs  # docker.io has no RPM packages for RHEL
-- urdfdom_py  # Build failures on RHEL https://github.com/ros/urdf_parser_py/pull/78
 - usb_cam  # ffmpeg has no RPM package for RHEL
 - vrpn_mocap  # Requires unreleased changes: https://github.com/vrpn/vrpn/pull/278
 - warehouse_ros_mongo  # mongodb has no RPM package for RHEL


### PR DESCRIPTION
With the merge of https://github.com/ros/urdf_parser_py/pull/78, it should build now.