### PR TITLE
Blacklist gz_ros2_control on RHEL

### DIFF
--- a/iron/release-rhel-build.yaml
+++ b/iron/release-rhel-build.yaml
@@ -25,6 +25,7 @@ package_blacklist:
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
 - geometric_shapes  # assimp has no RPM packages for RHEL 9
+- gz_ros2_control # Gazebo has no RPM package
 - hpp-fcl  # assimp has no RPM packages for RHEL 9
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL

--- a/iron/release-rhel-build.yaml
+++ b/iron/release-rhel-build.yaml
@@ -25,7 +25,7 @@ package_blacklist:
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
 - geometric_shapes  # assimp has no RPM packages for RHEL 9
-- gz_ros2_control # Gazebo has no RPM package
+- gz_ros2_control  # Gazebo has no RPM package
 - hpp-fcl  # assimp has no RPM packages for RHEL 9
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL


### PR DESCRIPTION
`gz_ros2_control` was added to rosdistro [here](https://github.com/ros/rosdistro/pull/37988). However build will fail on RHEL as gz is not supported here. See failing job:
* https://build.ros2.org/job/Isrc_el9__gz_ros2_control__rhel_9__source/