### PR TITLE
Update release-ubuntu-arm64-build.yaml

### DIFF
--- a/iron/release-ubuntu-arm64-build.yaml
+++ b/iron/release-ubuntu-arm64-build.yaml
@@ -16,7 +16,7 @@ package_blacklist:
 - kortex_api  # Kinova does not provide arm64, only armv7. https://github.com/PickNikRobotics/ros2_kortex/issues/158
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
-- mapviz # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
+- mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
 package_dependency_behavior:
   run_package_tests: false
 sync:

--- a/iron/release-ubuntu-arm64-build.yaml
+++ b/iron/release-ubuntu-arm64-build.yaml
@@ -16,6 +16,7 @@ package_blacklist:
 - kortex_api  # Kinova does not provide arm64, only armv7. https://github.com/PickNikRobotics/ros2_kortex/issues/158
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
+- mapviz # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
 package_dependency_behavior:
   run_package_tests: false
 sync:


### PR DESCRIPTION
Blacklisting SwRI package that the maintainers know does not build on Arm