### PR TITLE
Blacklist nav2 pkgs on Rolling and Iron

### DIFF
--- a/iron/release-rhel-build.yaml
+++ b/iron/release-rhel-build.yaml
@@ -21,6 +21,11 @@ package_blacklist:
 - ament_download  # Build failures on RHEL https://github.com/samsung-ros/ament_download/pull/3
 - apex_containers  # Build failures on RHEL due to -Werror
 - control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 9
+- costmap_queue  # nav2 build failures on RHEL
+- dwb_core  # nav2 build failures on RHEL
+- dwb_critics  # nav2 build failures on RHEL
+- dwb_msgs  # nav2 build failures on RHEL
+- dwb_plugins  # nav2 build failures on RHEL
 - four_wheel_steering_msgs  # Requires unreleased changes
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
@@ -37,6 +42,39 @@ package_blacklist:
 - moveit_resources_prbt_support  # libogre-dev has no RPM package for RHEL
 - mrpt2  # ffmpeg has no RPM package in supported repositories
 - mrt_cmake_modules  # Build failes due to ambiguous Python shebang
+- nav2_amcl  # nav2 build failures on RHEL
+- nav2_behavior_tree  # nav2 build failures on RHEL
+- nav2_behaviors  # nav2 build failures on RHEL
+- nav2_bringup  # nav2 build failures on RHEL
+- nav2_bt_navigator  # nav2 build failures on RHEL
+- nav2_collision_monitor  # nav2 build failures on RHEL
+- nav2_common  # nav2 build failures on RHEL
+- nav2_constrained_smoother  # nav2 build failures on RHEL
+- nav2_controller  # nav2 build failures on RHEL
+- nav2_core  # nav2 build failures on RHEL
+- nav2_costmap_2d  # nav2 build failures on RHEL
+- nav2_dwb_controller  # nav2 build failures on RHEL
+- nav2_lifecycle_manager  # nav2 build failures on RHEL
+- nav2_map_server  # nav2 build failures on RHEL
+- nav2_mppi_controller  # nav2 build failures on RHEL
+- nav2_msgs  # nav2 build failures on RHEL
+- nav2_navfn_planner  # nav2 build failures on RHEL
+- nav2_planner  # nav2 build failures on RHEL
+- nav2_regulated_pure_pursuit_controller  # nav2 build failures on RHEL
+- nav2_rotation_shim_controller  # nav2 build failures on RHEL
+- nav2_rviz_plugins  # nav2 build failures on RHEL
+- nav2_simple_commander  # nav2 build failures on RHEL
+- nav2_smac_planner  # nav2 build failures on RHEL
+- nav2_smoother  # nav2 build failures on RHEL
+- nav2_system_tests  # nav2 build failures on RHEL
+- nav2_theta_star_planner  # nav2 build failures on RHEL
+- nav2_util  # nav2 build failures on RHEL
+- nav2_velocity_smoother  # nav2 build failures on RHEL
+- nav2_voxel_grid  # nav2 build failures on RHEL
+- nav2_waypoint_follower  # nav2 build failures on RHEL
+- nav_2d_msgs  # nav2 build failures on RHEL
+- nav_2d_utils  # nav2 build failures on RHEL
+- navigation2  # nav2 build failures on RHEL
 - octomap_rviz_plugins  # Build failures on RHEL
 - octomap_server  # Build failures on RHEL
 - octovis  # Build failures on RHEL

--- a/iron/release-rhel-build.yaml
+++ b/iron/release-rhel-build.yaml
@@ -21,11 +21,11 @@ package_blacklist:
 - ament_download  # Build failures on RHEL https://github.com/samsung-ros/ament_download/pull/3
 - apex_containers  # Build failures on RHEL due to -Werror
 - control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 9
-- costmap_queue  # nav2 build failures on RHEL
-- dwb_core  # nav2 build failures on RHEL
-- dwb_critics  # nav2 build failures on RHEL
-- dwb_msgs  # nav2 build failures on RHEL
-- dwb_plugins  # nav2 build failures on RHEL
+- costmap_queue  # xtensor dependency cannot be installed via rosdep for RHEL
+- dwb_core  # xtensor dependency cannot be installed via rosdep for RHEL
+- dwb_critics  # xtensor dependency cannot be installed via rosdep for RHEL
+- dwb_msgs  # xtensor dependency cannot be installed via rosdep for RHEL
+- dwb_plugins  # xtensor dependency cannot be installed via rosdep for RHEL
 - four_wheel_steering_msgs  # Requires unreleased changes
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
@@ -42,39 +42,39 @@ package_blacklist:
 - moveit_resources_prbt_support  # libogre-dev has no RPM package for RHEL
 - mrpt2  # ffmpeg has no RPM package in supported repositories
 - mrt_cmake_modules  # Build failes due to ambiguous Python shebang
-- nav2_amcl  # nav2 build failures on RHEL
-- nav2_behavior_tree  # nav2 build failures on RHEL
-- nav2_behaviors  # nav2 build failures on RHEL
-- nav2_bringup  # nav2 build failures on RHEL
-- nav2_bt_navigator  # nav2 build failures on RHEL
-- nav2_collision_monitor  # nav2 build failures on RHEL
-- nav2_common  # nav2 build failures on RHEL
-- nav2_constrained_smoother  # nav2 build failures on RHEL
-- nav2_controller  # nav2 build failures on RHEL
-- nav2_core  # nav2 build failures on RHEL
-- nav2_costmap_2d  # nav2 build failures on RHEL
-- nav2_dwb_controller  # nav2 build failures on RHEL
-- nav2_lifecycle_manager  # nav2 build failures on RHEL
-- nav2_map_server  # nav2 build failures on RHEL
-- nav2_mppi_controller  # nav2 build failures on RHEL
-- nav2_msgs  # nav2 build failures on RHEL
-- nav2_navfn_planner  # nav2 build failures on RHEL
-- nav2_planner  # nav2 build failures on RHEL
-- nav2_regulated_pure_pursuit_controller  # nav2 build failures on RHEL
-- nav2_rotation_shim_controller  # nav2 build failures on RHEL
-- nav2_rviz_plugins  # nav2 build failures on RHEL
-- nav2_simple_commander  # nav2 build failures on RHEL
-- nav2_smac_planner  # nav2 build failures on RHEL
-- nav2_smoother  # nav2 build failures on RHEL
-- nav2_system_tests  # nav2 build failures on RHEL
-- nav2_theta_star_planner  # nav2 build failures on RHEL
-- nav2_util  # nav2 build failures on RHEL
-- nav2_velocity_smoother  # nav2 build failures on RHEL
-- nav2_voxel_grid  # nav2 build failures on RHEL
-- nav2_waypoint_follower  # nav2 build failures on RHEL
-- nav_2d_msgs  # nav2 build failures on RHEL
-- nav_2d_utils  # nav2 build failures on RHEL
-- navigation2  # nav2 build failures on RHEL
+- nav2_amcl  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_behavior_tree  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_behaviors  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_bringup  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_bt_navigator  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_collision_monitor  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_common  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_constrained_smoother  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_controller  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_core  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_costmap_2d  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_dwb_controller  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_lifecycle_manager  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_map_server  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_mppi_controller  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_msgs  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_navfn_planner  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_planner  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_regulated_pure_pursuit_controller  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_rotation_shim_controller  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_rviz_plugins  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_simple_commander  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_smac_planner  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_smoother  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_system_tests  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_theta_star_planner  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_util  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_velocity_smoother  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_voxel_grid  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_waypoint_follower  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav_2d_msgs  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav_2d_utils  # xtensor dependency cannot be installed via rosdep for RHEL
+- navigation2  # xtensor dependency cannot be installed via rosdep for RHEL
 - octomap_rviz_plugins  # Build failures on RHEL
 - octomap_server  # Build failures on RHEL
 - octovis  # Build failures on RHEL

--- a/iron/release-ubuntu-arm64-build.yaml
+++ b/iron/release-ubuntu-arm64-build.yaml
@@ -17,6 +17,7 @@ package_blacklist:
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
 - mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
+- nav2_bringup # depends on turtlebot3_gazebo which is unavailable
 package_dependency_behavior:
   run_package_tests: false
 sync:

--- a/iron/release-ubuntu-arm64-build.yaml
+++ b/iron/release-ubuntu-arm64-build.yaml
@@ -17,7 +17,7 @@ package_blacklist:
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
 - mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
-- nav2_bringup # depends on turtlebot3_gazebo which is unavailable
+- nav2_bringup  # depends on turtlebot3_gazebo which is unavailable
 package_dependency_behavior:
   run_package_tests: false
 sync:

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -17,11 +17,11 @@ package_blacklist:
 - ament_download  # Build failures on RHEL https://github.com/samsung-ros/ament_download/pull/3
 - apex_containers  # Build failures on RHEL due to -Werror
 - control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 9
-- costmap_queue  # nav2 build failures on RHEL
-- dwb_core  # nav2 build failures on RHEL
-- dwb_critics  # nav2 build failures on RHEL
-- dwb_msgs  # nav2 build failures on RHEL
-- dwb_plugins  # nav2 build failures on RHEL
+- costmap_queue  # xtensor dependency cannot be installed via rosdep for RHEL
+- dwb_core  # xtensor dependency cannot be installed via rosdep for RHEL
+- dwb_critics  # xtensor dependency cannot be installed via rosdep for RHEL
+- dwb_msgs  # xtensor dependency cannot be installed via rosdep for RHEL
+- dwb_plugins  # xtensor dependency cannot be installed via rosdep for RHEL
 - four_wheel_steering_msgs  # Requires unreleased changes
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
@@ -37,39 +37,39 @@ package_blacklist:
 - moveit_resources_prbt_support  # libogre-dev has no RPM package for RHEL
 - mrpt2  # ffmpeg has no RPM package in supported repositories
 - mrt_cmake_modules  # Build failes due to ambiguous Python shebang
-- nav2_amcl  # nav2 build failures on RHEL
-- nav2_behavior_tree  # nav2 build failures on RHEL
-- nav2_behaviors  # nav2 build failures on RHEL
-- nav2_bringup  # nav2 build failures on RHEL
-- nav2_bt_navigator  # nav2 build failures on RHEL
-- nav2_collision_monitor  # nav2 build failures on RHEL
-- nav2_common  # nav2 build failures on RHEL
-- nav2_constrained_smoother  # nav2 build failures on RHEL
-- nav2_controller  # nav2 build failures on RHEL
-- nav2_core  # nav2 build failures on RHEL
-- nav2_costmap_2d  # nav2 build failures on RHEL
-- nav2_dwb_controller  # nav2 build failures on RHEL
-- nav2_lifecycle_manager  # nav2 build failures on RHEL
-- nav2_map_server  # nav2 build failures on RHEL
-- nav2_mppi_controller  # nav2 build failures on RHEL
-- nav2_msgs  # nav2 build failures on RHEL
-- nav2_navfn_planner  # nav2 build failures on RHEL
-- nav2_planner  # nav2 build failures on RHEL
-- nav2_regulated_pure_pursuit_controller  # nav2 build failures on RHEL
-- nav2_rotation_shim_controller  # nav2 build failures on RHEL
-- nav2_rviz_plugins  # nav2 build failures on RHEL
-- nav2_simple_commander  # nav2 build failures on RHEL
-- nav2_smac_planner  # nav2 build failures on RHEL
-- nav2_smoother  # nav2 build failures on RHEL
-- nav2_system_tests  # nav2 build failures on RHEL
-- nav2_theta_star_planner  # nav2 build failures on RHEL
-- nav2_util  # nav2 build failures on RHEL
-- nav2_velocity_smoother  # nav2 build failures on RHEL
-- nav2_voxel_grid  # nav2 build failures on RHEL
-- nav2_waypoint_follower  # nav2 build failures on RHEL
-- nav_2d_msgs  # nav2 build failures on RHEL
-- nav_2d_utils  # nav2 build failures on RHEL
-- navigation2  # nav2 build failures on RHEL
+- nav2_amcl  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_behavior_tree  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_behaviors  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_bringup  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_bt_navigator  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_collision_monitor  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_common  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_constrained_smoother  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_controller  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_core  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_costmap_2d  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_dwb_controller  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_lifecycle_manager  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_map_server  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_mppi_controller  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_msgs  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_navfn_planner  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_planner  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_regulated_pure_pursuit_controller  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_rotation_shim_controller  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_rviz_plugins  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_simple_commander  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_smac_planner  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_smoother  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_system_tests  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_theta_star_planner  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_util  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_velocity_smoother  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_voxel_grid  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav2_waypoint_follower  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav_2d_msgs  # xtensor dependency cannot be installed via rosdep for RHEL
+- nav_2d_utils  # xtensor dependency cannot be installed via rosdep for RHEL
+- navigation2  # xtensor dependency cannot be installed via rosdep for RHEL
 - octomap_rviz_plugins  # Build failures on RHEL
 - octomap_server  # Build failures on RHEL
 - octovis  # Build failures on RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -17,6 +17,11 @@ package_blacklist:
 - ament_download  # Build failures on RHEL https://github.com/samsung-ros/ament_download/pull/3
 - apex_containers  # Build failures on RHEL due to -Werror
 - control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 9
+- costmap_queue  # nav2 build failures on RHEL
+- dwb_core  # nav2 build failures on RHEL
+- dwb_critics  # nav2 build failures on RHEL
+- dwb_msgs  # nav2 build failures on RHEL
+- dwb_plugins  # nav2 build failures on RHEL
 - four_wheel_steering_msgs  # Requires unreleased changes
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
@@ -32,6 +37,39 @@ package_blacklist:
 - moveit_resources_prbt_support  # libogre-dev has no RPM package for RHEL
 - mrpt2  # ffmpeg has no RPM package in supported repositories
 - mrt_cmake_modules  # Build failes due to ambiguous Python shebang
+- nav2_amcl  # nav2 build failures on RHEL
+- nav2_behavior_tree  # nav2 build failures on RHEL
+- nav2_behaviors  # nav2 build failures on RHEL
+- nav2_bringup  # nav2 build failures on RHEL
+- nav2_bt_navigator  # nav2 build failures on RHEL
+- nav2_collision_monitor  # nav2 build failures on RHEL
+- nav2_common  # nav2 build failures on RHEL
+- nav2_constrained_smoother  # nav2 build failures on RHEL
+- nav2_controller  # nav2 build failures on RHEL
+- nav2_core  # nav2 build failures on RHEL
+- nav2_costmap_2d  # nav2 build failures on RHEL
+- nav2_dwb_controller  # nav2 build failures on RHEL
+- nav2_lifecycle_manager  # nav2 build failures on RHEL
+- nav2_map_server  # nav2 build failures on RHEL
+- nav2_mppi_controller  # nav2 build failures on RHEL
+- nav2_msgs  # nav2 build failures on RHEL
+- nav2_navfn_planner  # nav2 build failures on RHEL
+- nav2_planner  # nav2 build failures on RHEL
+- nav2_regulated_pure_pursuit_controller  # nav2 build failures on RHEL
+- nav2_rotation_shim_controller  # nav2 build failures on RHEL
+- nav2_rviz_plugins  # nav2 build failures on RHEL
+- nav2_simple_commander  # nav2 build failures on RHEL
+- nav2_smac_planner  # nav2 build failures on RHEL
+- nav2_smoother  # nav2 build failures on RHEL
+- nav2_system_tests  # nav2 build failures on RHEL
+- nav2_theta_star_planner  # nav2 build failures on RHEL
+- nav2_util  # nav2 build failures on RHEL
+- nav2_velocity_smoother  # nav2 build failures on RHEL
+- nav2_voxel_grid  # nav2 build failures on RHEL
+- nav2_waypoint_follower  # nav2 build failures on RHEL
+- nav_2d_msgs  # nav2 build failures on RHEL
+- nav_2d_utils  # nav2 build failures on RHEL
+- navigation2  # nav2 build failures on RHEL
 - octomap_rviz_plugins  # Build failures on RHEL
 - octomap_server  # Build failures on RHEL
 - octovis  # Build failures on RHEL

--- a/rolling/release-ubuntu-arm64-build.yaml
+++ b/rolling/release-ubuntu-arm64-build.yaml
@@ -17,6 +17,7 @@ package_blacklist:
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
 - mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
+- nav2_bringup # depends on turtlebot3_gazebo which is unavailable
 sync:
   package_count: 499
   packages: [desktop]

--- a/rolling/release-ubuntu-arm64-build.yaml
+++ b/rolling/release-ubuntu-arm64-build.yaml
@@ -17,7 +17,6 @@ package_blacklist:
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
 - mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
-- nav2_bringup # depends on turtlebot3_gazebo which is unavailable
 sync:
   package_count: 499
   packages: [desktop]


### PR DESCRIPTION
This PR blacklists
* All nav2 pkgs on RHEl 9: See failures https://repo.ros2.org/status_page/ros_iron_rhel.html
* `nav2_bringup` on arm64: https://build.ros2.org/view/Ibin_ujv8_uJv8/job/Ibin_ujv8_uJv8__nav2_bringup__ubuntu_jammy_arm64__binary/

for Rolling and Iron.

cc: @SteveMacenski

