### PR TITLE
Remove SwRI Packages from Blacklist

### DIFF
--- a/rolling/release-build.yaml
+++ b/rolling/release-build.yaml
@@ -15,10 +15,6 @@ notifications:
   - steven+build.ros2.org@openrobotics.org
   - ros2-buildfarm-rolling@googlegroups.com
   maintainers: true
-package_blacklist:
-- swri_console_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
-- swri_geometry_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
-- swri_roscpp  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
 sync:
   package_count: 499
   packages: [desktop]


### PR DESCRIPTION
These packages are currently building and released on Iron. This is holding up the release of other downstream packages.