### PR TITLE
Remove SwRI blacklisted packages

### DIFF
--- a/humble/release-build.yaml
+++ b/humble/release-build.yaml
@@ -15,10 +15,6 @@ notifications:
   - audrow+build.ros2.org@openrobotics.org
   - ros2-buildfarm-humble@googlegroups.com
   maintainers: true
-package_blacklist:
-- swri_console_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
-- swri_geometry_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
-- swri_roscpp  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665
 sync:
   package_count: 499
   packages: [desktop]


### PR DESCRIPTION
These are currently building and unblacklisted in Iron. Keeping them blacklisted in Humble is preventing downstream packages from building.