### PR TITLE
Pass -mno-avx512f flag to disable AVX512 opcodes in debs

### DIFF
--- a/humble/release-build.yaml
+++ b/humble/release-build.yaml
@@ -4,6 +4,9 @@
 abi_incompatibility_assumed: true
 
 build_environment_variables:
+  # Disable AVX512 opcodes in case we build on Xeon
+  DEB_CFLAGS_MAINT_APPEND: -mno-avx512f
+  DEB_CXXFLAGS_MAINT_APPEND: -mno-avx512f
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 
 jenkins_binary_job_priority: 85

--- a/iron/release-build.yaml
+++ b/iron/release-build.yaml
@@ -4,6 +4,9 @@
 abi_incompatibility_assumed: true
 
 build_environment_variables:
+  # Disable AVX512 opcodes in case we build on Xeon
+  DEB_CFLAGS_MAINT_APPEND: -mno-avx512f
+  DEB_CXXFLAGS_MAINT_APPEND: -mno-avx512f
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 
 jenkins_binary_job_priority: 84

--- a/rolling/release-build.yaml
+++ b/rolling/release-build.yaml
@@ -4,6 +4,9 @@
 abi_incompatibility_assumed: true
 
 build_environment_variables:
+  # Disable AVX512 opcodes in case we build on Xeon
+  DEB_CFLAGS_MAINT_APPEND: -mno-avx512f
+  DEB_CXXFLAGS_MAINT_APPEND: -mno-avx512f
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 
 jenkins_binary_job_priority: 80


### PR DESCRIPTION
It seems that when we build packages on Xeon systems which support the AVX512 extension, the corresponding opcode is used in the resulting binaries. This leads to SIGILL on platforms which don't support the extension, so we should explicitly disable it to maintain wide compatibility.

I verified that the flag was passed through to gcc by invoking the buildfarm locally using `generate_release_script`.