### PR TITLE
Unblocked several packages waiting on RHEL 9 deps

### DIFF
--- a/iron/release-rhel-build.yaml
+++ b/iron/release-rhel-build.yaml
@@ -24,15 +24,11 @@ package_blacklist:
 - four_wheel_steering_msgs  # Requires unreleased changes
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
-- geometric_shapes  # assimp has no RPM packages for RHEL 9
 - gz_ros2_control  # Gazebo has no RPM package
-- hpp-fcl  # assimp has no RPM packages for RHEL 9
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL
 - kobuki_core  # Build failures on RHEL
-- kobuki_velocity_smoother  # python3-matplotlib has no RPM package for RHEL 9
-- mavros  # GeographicLib has no RPM packages for RHEL
 - moveit_common  # libogre-dev has no RPM package for RHEL
 - moveit_resources_prbt_support  # libogre-dev has no RPM package for RHEL
 - mrpt2  # ffmpeg has no RPM package in supported repositories
@@ -44,7 +40,6 @@ package_blacklist:
 - ompl  # opende has no RPM package for RHEL
 - open3d_conversions  # open3d has no RPM package for RHEL
 - openni2_camera  # libopenni2-dev does not exist on RHEL
-- ouster_msgs  # libtins-dev has no RPM package for RHEL
 - pepper_meshes  # Missing license agreement patches for packaging https://github.com/ros-naoqi/pepper_meshes2-release/issues/1
 - performance_test  # Missing dependency on git: https://gitlab.com/ApexAI/performance_test/-/merge_requests/371
 - proxsuite  # simde and matio have no RPM packages for RHEL 9
@@ -61,7 +56,6 @@ package_blacklist:
 - rmf_traffic_editor  # ignition has no RPM packages for RHEL
 - rmf_traffic_editor_assets  # ignition has no RPM packages for RHEL
 - rmf_traffic_ros2  # Build failures on RHEL https://github.com/open-rmf/rmf_ros2/issues/156
-- robot_localization  # GeographicLib has no RPM packages for RHEL 9
 - ros_ign_bridge  # ignition has no RPM packages for RHEL
 - ros_ign_gazebo  # ignition has no RPM packages for RHEL
 - ros_ign_interfaces  # ignition has no RPM packages for RHEL
@@ -113,7 +107,6 @@ package_ignore_list:
 - rosidl_typesupport_connext_cpp  # No RPM package for Connext
 - rosidl_typesupport_gurumdds_c  # No RPM package for GurumDDS
 - rosidl_typesupport_gurumdds_cpp  # No RPM package for GurumDDS
-- rqt_plot  # python3-matplotlib has no RPM for RHEL 9
 - rti_connext_dds_cmake_module  # No RPM package for Connext
 sync:
   package_count: 400

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -20,14 +20,10 @@ package_blacklist:
 - four_wheel_steering_msgs  # Requires unreleased changes
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
-- geometric_shapes  # assimp has no RPM packages for RHEL 9
-- hpp-fcl  # assimp has no RPM packages for RHEL 9
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL
 - kobuki_core  # Build failures on RHEL
-- kobuki_velocity_smoother  # python3-matplotlib has no RPM package for RHEL 9
-- mavros  # GeographicLib has no RPM packages for RHEL
 - moveit_common  # libogre-dev has no RPM package for RHEL
 - moveit_resources_prbt_support  # libogre-dev has no RPM package for RHEL
 - mrpt2  # ffmpeg has no RPM package in supported repositories
@@ -38,7 +34,6 @@ package_blacklist:
 - ompl  # opende has no RPM package for RHEL
 - open3d_conversions  # open3d has no RPM package for RHEL
 - openni2_camera  # libopenni2-dev does not exist on RHEL
-- ouster_msgs  # libtins-dev has no RPM package for RHEL
 - performance_test  # Missing dependency on git: https://gitlab.com/ApexAI/performance_test/-/merge_requests/371
 - proxsuite  # simde and matio have no RPM packages for RHEL 9
 - py_trees_js  # python3-pyqt5.qtwebengine has no RPM packages for RHEL 9
@@ -54,7 +49,6 @@ package_blacklist:
 - rmf_traffic_editor  # ignition has no RPM packages for RHEL
 - rmf_traffic_editor_assets  # ignition has no RPM packages for RHEL
 - rmf_traffic_ros2  # Build failures on RHEL https://github.com/open-rmf/rmf_ros2/issues/156
-- robot_localization  # GeographicLib has no RPM packages for RHEL 9
 - ros_ign_bridge  # ignition has no RPM packages for RHEL
 - ros_ign_gazebo  # ignition has no RPM packages for RHEL
 - ros_ign_interfaces  # ignition has no RPM packages for RHEL
@@ -106,7 +100,6 @@ package_ignore_list:
 - rosidl_typesupport_connext_cpp  # No RPM package for Connext
 - rosidl_typesupport_gurumdds_c  # No RPM package for GurumDDS
 - rosidl_typesupport_gurumdds_cpp  # No RPM package for GurumDDS
-- rqt_plot  # python3-matplotlib has no RPM for RHEL 9
 - rti_connext_dds_cmake_module  # No RPM package for Connext
 sync:
   package_count: 400


### PR DESCRIPTION
These packages were blocked due to missing upstream dependencies which are now available in EPEL 9.

No promises that they actually build, but the fastest way to find out is to try. We can always re-add them if something doesn't work right.