### PR TITLE
Switch to using the humble branch of buildfarm_perf_tests.

### DIFF
--- a/humble/ci-nightly-performance.yaml
+++ b/humble/ci-nightly-performance.yaml
@@ -20,7 +20,7 @@ jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
 jenkins_job_weight: 4
 repos_files:
-- https://github.com/ros2/buildfarm_perf_tests/raw/master/tools/ros2_dependencies.repos
+- https://github.com/ros2/buildfarm_perf_tests/raw/humble/tools/ros2_dependencies.repos
 repositories:
   keys:
   - |


### PR DESCRIPTION
This is because a recent update to performance_test is incompatible between Humble and Rolling, so we create a new branch.

Note that https://github.com/ros2/buildfarm_perf_tests/pull/112 has to be merged first.