### PR TITLE
Run Rolling source and release jobs on noble.

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -89,7 +89,7 @@ distributions:
     release_builds:
       default: rolling/release-build.yaml
       rhel: rolling/release-rhel-build.yaml
-      ujv8: rolling/release-ubuntu-arm64-build.yaml
+      unv8: rolling/release-ubuntu-arm64-build.yaml
     source_builds:
       default: rolling/source-build.yaml
 jenkins_url: https://build.ros2.org

--- a/rolling/doc-build.yaml
+++ b/rolling/doc-build.yaml
@@ -49,7 +49,7 @@ repositories:
   - http://repo.ros2.org/ubuntu/testing/
 targets:
   ubuntu:
-    jammy:
+    noble:
       amd64:
 type: doc-build
 upload_credential_id: jenkins-agent

--- a/rolling/release-build.yaml
+++ b/rolling/release-build.yaml
@@ -56,7 +56,7 @@ repositories:
 target_repository: http://repo.ros2.org/ubuntu/building
 targets:
   ubuntu:
-    jammy:
+    noble:
       amd64:
 type: release-build
 upload_credential_id: jenkins-agent

--- a/rolling/release-ubuntu-arm64-build.yaml
+++ b/rolling/release-ubuntu-arm64-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm release-build file
 ---
 abi_incompatibility_assumed: true
-jenkins_binary_job_label: buildagent_arm64 || rolling_binarydeb_ujv8
+jenkins_binary_job_label: buildagent_arm64 || rolling_binarydeb_unv8
 jenkins_binary_job_priority: 80
 jenkins_binary_job_timeout: 720
 jenkins_source_job_priority: 70
@@ -58,7 +58,7 @@ repositories:
 target_repository: http://repo.ros2.org/ubuntu/building
 targets:
   ubuntu:
-    jammy:
+    noble:
       arm64:
 type: release-build
 upload_credential_id: jenkins-agent

--- a/rolling/source-build.yaml
+++ b/rolling/source-build.yaml
@@ -55,7 +55,7 @@ repository_blacklist:
 - ros_workspace
 targets:
   ubuntu:
-    jammy:
+    noble:
       amd64:
 test_commits:
   default: true


### PR DESCRIPTION
Updates the Rolling build targets for the transition to ROS 2 Rolling Ridley.

Having these jobs up and running is a pre-requisite for CI jobs due to the reliance on a ros_workspace package.