### PR TITLE
Change RHEL-9 ur exclusion to ur_robot_driver

### DIFF
--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -56,7 +56,7 @@ package_blacklist:
 - sol_vendor  # Targets 'HEAD' in vendor package
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
 - tvm_vendor  # Build failures on AlmaLinux (but not RHEL)
-- ur_dashboard_msgs  # docker.io has no RPM packages for RHEL
+- ur_robot_driver  # docker.io has no RPM packages for RHEL
 - usb_cam  # v4l-utils has no RPM package for RHEL
 - vrpn_mocap  # Requires unreleased changes: https://github.com/vrpn/vrpn/pull/278
 - warehouse_ros_mongo  # mongodb has no RPM package for RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -56,7 +56,7 @@ package_blacklist:
 - sol_vendor  # Targets 'HEAD' in vendor package
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
 - tvm_vendor  # Build failures on AlmaLinux (but not RHEL)
-- ur_robot_driver  # docker.io has no RPM packages for RHEL
+- ur_dashboard_msgs  # Upstream for ur_robot_driver, for which docker.io has no RPM packages for RHEL
 - usb_cam  # v4l-utils has no RPM package for RHEL
 - vrpn_mocap  # Requires unreleased changes: https://github.com/vrpn/vrpn/pull/278
 - warehouse_ros_mongo  # mongodb has no RPM package for RHEL


### PR DESCRIPTION
As far as I can tell, it is the `ur_robot_driver` package that requires `docker.io`, not `ur_dashboard_msgs`.  That is borne out by both the code (https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/blob/2048d1450e4d76efd2a7be3213373ef6ac4932c2/ur_robot_driver/package.xml#L62), and by a recent attempt to bloom this:

```
Failed to resolve docker.io on rhel:9 with: Error running generator: Failed to resolve rosdep key 'docker.io', aborting.
docker.io is depended on by these packages: ['ur_robot_driver']
```