### PR TITLE
Add bno055 to the blacklist

### DIFF
--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -15,6 +15,7 @@ notifications:
 package_blacklist:
 - acado_vendor  # Requires unreleased changes
 - ament_download  # Build failures on RHEL https://github.com/samsung-ros/ament_download/pull/3
+- bno055  # python3-smbus has no RPM for RHEL 9
 - control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 9
 - four_wheel_steering_msgs  # Requires unreleased changes
 - fuse_constraints  # Requires unreleased changes


### PR DESCRIPTION
As of version 0.5.0, the bno055 package has a dependency on python3-smbus: https://github.com/flynneva/bno055/blob/45e1ff16936101711260c9fda63fbad99376ce3b/package.xml#L14 .

Since that doesn't seem to exist for RHEL-9 (https://pkgs.org/download/python3-smbus), blacklist the package for now.