### PR TITLE
Blacklist ament_black from RHEL-9

### DIFF
--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -14,6 +14,7 @@ notifications:
   maintainers: false
 package_blacklist:
 - acado_vendor  # Requires unreleased changes
+- ament_black  # python3-uvloop and black have no RPM packages for RHEL
 - ament_download  # Build failures on RHEL https://github.com/samsung-ros/ament_download/pull/3
 - control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 9
 - four_wheel_steering_msgs  # Requires unreleased changes


### PR DESCRIPTION
It requires two packages that don't seem to have packages in RHEL: python3-uvloop and black.  Just disable the package.

This has been failing to build the source RPM for as long as we have history: https://build.ros2.org/job/Rsrc_el9__ament_black__rhel_9__source/98/console