### PR TITLE
Stop installing deps for and running tests in Rolling packages

### DIFF
--- a/rolling/release-build.yaml
+++ b/rolling/release-build.yaml
@@ -15,6 +15,9 @@ notifications:
   - steven+build.ros2.org@openrobotics.org
   - ros2-buildfarm-rolling@googlegroups.com
   maintainers: true
+package_dependency_behavior:
+  include_test_dependencies: false
+  run_package_tests: false
 sync:
   package_count: 499
   packages: [desktop]

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -76,6 +76,9 @@ package_blacklist:
 - webots_ros2_ur_e_description  # Not yet generated for RHEL
 - wiimote  # cwiid has no RPM package for RHEL
 - zmqpp_vendor  # Targets 'HEAD' in vendor package
+package_dependency_behavior:
+  include_test_dependencies: false
+  run_package_tests: false
 package_ignore_list:
 - connext_cmake_module  # No RPM package for Connext
 - demo_nodes_cpp_native_gurumdds  # No RPM package for GurumDDS

--- a/rolling/release-ubuntu-arm64-build.yaml
+++ b/rolling/release-ubuntu-arm64-build.yaml
@@ -17,6 +17,9 @@ package_blacklist:
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
 - mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
+package_dependency_behavior:
+  include_test_dependencies: false
+  run_package_tests: false
 sync:
   package_count: 499
   packages: [desktop]


### PR DESCRIPTION
This was already done in ROS 2 Iron, but we were unable to do it in Rolling at the time without re-releasing every package. That happened as part of the Ubuntu Noble migration, so we can now disable the tests in deb and RPM jobs in Rolling.