### PR TITLE
Update docs upload configuration.

### DIFF
--- a/humble/doc-build.yaml
+++ b/humble/doc-build.yaml
@@ -52,8 +52,8 @@ targets:
     jammy:
       amd64:
 type: doc-build
-upload_credential_id: jenkins-agent
+upload_credential_id: rosdocs
 upload_host: docs.ros.org
 upload_root: /var/www/docs.ros.org/en/ros2_packages
-upload_user: rosbot
+upload_user: rosdocs
 version: 2

--- a/iron/doc-build.yaml
+++ b/iron/doc-build.yaml
@@ -52,8 +52,8 @@ targets:
     jammy:
       amd64:
 type: doc-build
-upload_credential_id: jenkins-agent
+upload_credential_id: rosdocs
 upload_host: docs.ros.org
 upload_root: /var/www/docs.ros.org/en/ros2_packages
-upload_user: rosbot
+upload_user: rosdocs
 version: 2

--- a/jazzy/doc-build.yaml
+++ b/jazzy/doc-build.yaml
@@ -52,8 +52,8 @@ targets:
     noble:
       amd64:
 type: doc-build
-upload_credential_id: jenkins-agent
+upload_credential_id: rosdocs
 upload_host: docs.ros.org
 upload_root: /var/www/docs.ros.org/en/ros2_packages
-upload_user: rosbot
+upload_user: rosdocs
 version: 2

--- a/rolling/doc-build.yaml
+++ b/rolling/doc-build.yaml
@@ -52,8 +52,8 @@ targets:
     noble:
       amd64:
 type: doc-build
-upload_credential_id: jenkins-agent
+upload_credential_id: rosdocs
 upload_host: docs.ros.org
 upload_root: /var/www/docs.ros.org/en/ros2_packages
-upload_user: rosbot
+upload_user: rosdocs
 version: 2


### PR DESCRIPTION
In preparation for moving docs.ros.org to the new web host, we're rolling out a new set of deploy keys as well as a dedicated user account just for the docs.

This change needs to be merged in coordination with the Jenkins deployment of the new credential and updated DNS for docs.ros.org as these keys nor configuration are valid on the current docs host.