### PR TITLE
openvdb_vendor in backlist for RHEL

### DIFF
--- a/humble/release-rhel-build.yaml
+++ b/humble/release-rhel-build.yaml
@@ -34,6 +34,7 @@ package_blacklist:
 - octovis  # Build failures on RHEL
 - open3d_conversions  # open3d has no RPM package for RHEL
 - openni2_camera  # libopenni2-dev does not exist on RHEL
+- openvdb_vendor  # CMake version too old on RHEL for OpenVDB
 - ouster_msgs  # libtins-dev has no RPM package for RHEL
 - pepper_meshes  # Missing license agreement patches for packaging https://github.com/ros-naoqi/pepper_meshes2-release/issues/1
 - popf  # COIN-OR packages have no RPM packages for RHEL 8

--- a/humble/release-rhel-build.yaml
+++ b/humble/release-rhel-build.yaml
@@ -34,7 +34,7 @@ package_blacklist:
 - octovis  # Build failures on RHEL
 - open3d_conversions  # open3d has no RPM package for RHEL
 - openni2_camera  # libopenni2-dev does not exist on RHEL
-- openvdb_vendor  # CMake version too old on RHEL for OpenVDB
+- openvdb_vendor  # g++ version too old on RHEL for OpenVDB
 - ouster_msgs  # libtins-dev has no RPM package for RHEL
 - pepper_meshes  # Missing license agreement patches for packaging https://github.com/ros-naoqi/pepper_meshes2-release/issues/1
 - popf  # COIN-OR packages have no RPM packages for RHEL 8

--- a/iron/release-rhel-build.yaml
+++ b/iron/release-rhel-build.yaml
@@ -38,6 +38,7 @@ package_blacklist:
 - ompl  # opende has no RPM package for RHEL
 - open3d_conversions  # open3d has no RPM package for RHEL
 - openni2_camera  # libopenni2-dev does not exist on RHEL
+- openvdb_vendor  # CMake version too old on RHEL for OpenVDB
 - pepper_meshes  # Missing license agreement patches for packaging https://github.com/ros-naoqi/pepper_meshes2-release/issues/1
 - performance_test  # Missing dependency on git: https://gitlab.com/ApexAI/performance_test/-/merge_requests/371
 - proxsuite  # simde and matio have no RPM packages for RHEL 9

--- a/iron/release-rhel-build.yaml
+++ b/iron/release-rhel-build.yaml
@@ -38,7 +38,6 @@ package_blacklist:
 - ompl  # opende has no RPM package for RHEL
 - open3d_conversions  # open3d has no RPM package for RHEL
 - openni2_camera  # libopenni2-dev does not exist on RHEL
-- openvdb_vendor  # CMake version too old on RHEL for OpenVDB
 - pepper_meshes  # Missing license agreement patches for packaging https://github.com/ros-naoqi/pepper_meshes2-release/issues/1
 - performance_test  # Missing dependency on git: https://gitlab.com/ApexAI/performance_test/-/merge_requests/371
 - proxsuite  # simde and matio have no RPM packages for RHEL 9


### PR DESCRIPTION
Build fails since OpenVDB requires a newer Cmake than RHEL has for Humble/Iron