### PR TITLE
Allow building `sdformat_urdf` and `sdformat_test_files` on RHEL

### DIFF
--- a/jazzy/release-rhel-build.yaml
+++ b/jazzy/release-rhel-build.yaml
@@ -52,8 +52,6 @@ package_blacklist:
 - ros_industrial_cmake_boilerplate  # iwyu has no RPM packages for RHEL 9
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
 - rsl  # Requires CMake 3.22
-- sdformat_test_files  # sdformat has no RPM packages for RHEL 9
-- sdformat_urdf  # sdformat has no RPM packages for RHEL 9
 - sol_vendor  # Targets 'HEAD' in vendor package
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
 - tvm_vendor  # Build failures on AlmaLinux (but not RHEL)

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -49,8 +49,6 @@ package_blacklist:
 - ros_ign_interfaces  # ignition has no RPM packages for RHEL
 - ros_industrial_cmake_boilerplate  # iwyu has no RPM packages for RHEL 9
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
-- sdformat_test_files  # sdformat has no RPM packages for RHEL 9
-- sdformat_urdf  # sdformat has no RPM packages for RHEL 9
 - sol_vendor  # Targets 'HEAD' in vendor package
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
 - tvm_vendor  # Build failures on AlmaLinux (but not RHEL)


### PR DESCRIPTION
Removes these packages from the blacklists in Jazzy and Rolling release builds for RHEL since RPM packages are now available for `sdformat` via `sdformat_vendor`.

See https://github.com/ros/sdformat_urdf/issues/36 for more context.