### PR TITLE
Add ROS_DISTRO to doc job environments

### DIFF
--- a/humble/doc-build.yaml
+++ b/humble/doc-build.yaml
@@ -2,6 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 build_environment_variables:
+  ROS_DISTRO: humble
   ROS_PYTHON_VERSION: 3
 canonical_base_url: http://docs.ros.org/en
 documentation_type: rosdoc2

--- a/jazzy/doc-build.yaml
+++ b/jazzy/doc-build.yaml
@@ -2,6 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 build_environment_variables:
+  ROS_DISTRO: jazzy
   ROS_PYTHON_VERSION: 3
 canonical_base_url: http://docs.ros.org/en
 documentation_type: rosdoc2

--- a/rolling/doc-build.yaml
+++ b/rolling/doc-build.yaml
@@ -2,6 +2,7 @@
 # ROS buildfarm doc-build file
 ---
 build_environment_variables:
+  ROS_DISTRO: rolling
   ROS_PYTHON_VERSION: 3
 canonical_base_url: http://docs.ros.org/en
 documentation_type: rosdoc2


### PR DESCRIPTION
Leverages: https://github.com/ros-infrastructure/ros_buildfarm/pull/1079
Replacing: https://github.com/ros-infrastructure/ros_buildfarm/pull/1078