### PR TITLE
Blocklist rmf_demos_maps from all suites

### DIFF
--- a/jazzy/release-build.yaml
+++ b/jazzy/release-build.yaml
@@ -15,6 +15,8 @@ notifications:
   - steven+build.ros2.org@openrobotics.org
   - ros2-buildfarm-jazzy@googlegroups.com
   maintainers: true
+package_blacklist:
+- rmf_demos_maps # Missing assets https://github.com/open-rmf/rmf_demos/issues/274
 package_dependency_behavior:
   include_test_dependencies: false
   run_package_tests: false

--- a/rolling/release-build.yaml
+++ b/rolling/release-build.yaml
@@ -15,6 +15,8 @@ notifications:
   - steven+build.ros2.org@openrobotics.org
   - ros2-buildfarm-rolling@googlegroups.com
   maintainers: true
+package_blacklist:
+- rmf_demos_maps # Missing assets https://github.com/open-rmf/rmf_demos/issues/274
 package_dependency_behavior:
   include_test_dependencies: false
   run_package_tests: false


### PR DESCRIPTION
Based on https://github.com/open-rmf/rmf_demos/issues/274, we would like to distribute some packages in the `rmf_demos` repo but not all.
Specifically `rmf_demos_maps` builds successfully but has missing files that make it non-functional.
The proposed approach is to blocklist `rmf_demos_maps` from all suites in Jazzy and Rolling.

I admit not being familiar with the buildfarm, I noticed that the root `release-build` files didn't actually have a `package_blacklist` section so I'm not sure this is the right way to do it