### PR TITLE
add ROS_VERSION to doc build job environment

### DIFF
--- a/humble/doc-build.yaml
+++ b/humble/doc-build.yaml
@@ -4,6 +4,7 @@
 build_environment_variables:
   ROS_DISTRO: humble
   ROS_PYTHON_VERSION: 3
+  ROS_VERSION: 2
 canonical_base_url: http://docs.ros.org/en
 documentation_type: rosdoc2
 jenkins_job_priority: 89

--- a/jazzy/doc-build.yaml
+++ b/jazzy/doc-build.yaml
@@ -4,6 +4,7 @@
 build_environment_variables:
   ROS_DISTRO: jazzy
   ROS_PYTHON_VERSION: 3
+  ROS_VERSION: 2
 canonical_base_url: http://docs.ros.org/en
 documentation_type: rosdoc2
 jenkins_job_priority: 89

--- a/rolling/doc-build.yaml
+++ b/rolling/doc-build.yaml
@@ -4,6 +4,7 @@
 build_environment_variables:
   ROS_DISTRO: rolling
   ROS_PYTHON_VERSION: 3
+  ROS_VERSION: 2
 canonical_base_url: http://docs.ros.org/en
 documentation_type: rosdoc2
 jenkins_job_priority: 89


### PR DESCRIPTION
This replaces: https://github.com/ros-infrastructure/rosdoc2/pull/183 
Following the pattern of #314 providing the other variable from ros_environment.