### PR TITLE
Get the rmw_zenoh from ros2.repos (now that it's available)

### DIFF
--- a/rolling/ci-nightly-zenoh.yaml
+++ b/rolling/ci-nightly-zenoh.yaml
@@ -17,8 +17,6 @@ jenkins_job_weight: 4
 package_selection_args: '--packages-ignore foonathan_memory_vendor rosidl_dynamic_typesupport_fastrtps --packages-ignore-regex .*connext.* .*cyclonedds.* .*fastdds.* .*rmw_fastrtps.*'
 repos_files:
 - https://github.com/ros2/ros2/raw/rolling/ros2.repos
-repository_names:
-- rmw_zenoh
 repositories:
   keys:
   - |


### PR DESCRIPTION
I was listing the `rmw_zenoh` repository here for testing while we waited for ros2/ros2#1649 to land, but now that it's been merged, we actually need to remove this entry to avoid two copies of the repo.