### PR TITLE
:man_farmer: Increase timeout for Rci__nightly-release_ubuntu_noble_amd64

### DIFF
--- a/rolling/ci-nightly-release.yaml
+++ b/rolling/ci-nightly-release.yaml
@@ -11,7 +11,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
-jenkins_job_timeout: 300
+jenkins_job_timeout: 360
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:


### PR DESCRIPTION
As the title says. Saving this PR in the list of triage items for the Buildfarm+ROS2 weekly so we can revert it back at some point.