### PR TITLE
Adjust job priorities for Jazzy

### DIFF
--- a/jazzy/ci-benchmark.yaml
+++ b/jazzy/ci-benchmark.yaml
@@ -14,7 +14,7 @@ build_tool_test_args: '--ctest-args -L performance --pytest-args -m performance'
 install_packages:
 - libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_timeout: 240
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release

--- a/jazzy/ci-nightly-connext.yaml
+++ b/jazzy/ci-nightly-connext.yaml
@@ -9,7 +9,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4

--- a/jazzy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/jazzy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -14,7 +14,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 install_packages:
 - libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-release

--- a/jazzy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/jazzy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -14,7 +14,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 install_packages:
 - libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release

--- a/jazzy/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/jazzy/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -12,7 +12,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 install_packages:
 - libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-release

--- a/jazzy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/jazzy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -13,7 +13,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 install_packages:
 - libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release

--- a/jazzy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/jazzy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -11,7 +11,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 install_packages:
 - libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-release

--- a/jazzy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/jazzy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -11,7 +11,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 install_packages:
 - libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_timeout: 300
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release

--- a/jazzy/ci-nightly-cyclonedds.yaml
+++ b/jazzy/ci-nightly-cyclonedds.yaml
@@ -7,7 +7,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4

--- a/jazzy/ci-nightly-debug.yaml
+++ b/jazzy/ci-nightly-debug.yaml
@@ -9,7 +9,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 360
 jenkins_job_weight: 4

--- a/jazzy/ci-nightly-extra-rmw-release.yaml
+++ b/jazzy/ci-nightly-extra-rmw-release.yaml
@@ -9,7 +9,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4

--- a/jazzy/ci-nightly-fastrtps-dynamic.yaml
+++ b/jazzy/ci-nightly-fastrtps-dynamic.yaml
@@ -7,7 +7,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4

--- a/jazzy/ci-nightly-fastrtps.yaml
+++ b/jazzy/ci-nightly-fastrtps.yaml
@@ -7,7 +7,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4

--- a/jazzy/ci-nightly-performance.yaml
+++ b/jazzy/ci-nightly-performance.yaml
@@ -14,7 +14,7 @@ install_packages:
 - libssl-dev  # for Fast-DDS security
 - libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_timeout: 180
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release

--- a/jazzy/ci-nightly-release.yaml
+++ b/jazzy/ci-nightly-release.yaml
@@ -9,7 +9,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_schedule: 15 23 1-31/3 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4

--- a/jazzy/ci-overlay.yaml
+++ b/jazzy/ci-overlay.yaml
@@ -9,7 +9,7 @@ build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
-jenkins_job_priority: 50
+jenkins_job_priority: 53
 jenkins_job_timeout: 240
 jenkins_job_weight: 4
 repos_files:

--- a/jazzy/release-build.yaml
+++ b/jazzy/release-build.yaml
@@ -6,9 +6,9 @@ abi_incompatibility_assumed: true
 build_environment_variables:
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 
-jenkins_binary_job_priority: 80
+jenkins_binary_job_priority: 83
 jenkins_binary_job_timeout: 150
-jenkins_source_job_priority: 70
+jenkins_source_job_priority: 73
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/jazzy/release-rhel-build.yaml
+++ b/jazzy/release-rhel-build.yaml
@@ -6,9 +6,9 @@ abi_incompatibility_assumed: true
 build_environment_variables:
   RPM_BUILD_NCPUS: '1'
 
-jenkins_binary_job_priority: 80
+jenkins_binary_job_priority: 83
 jenkins_binary_job_timeout: 150
-jenkins_source_job_priority: 70
+jenkins_source_job_priority: 73
 jenkins_source_job_timeout: 30
 notifications:
   maintainers: false

--- a/jazzy/release-ubuntu-arm64-build.yaml
+++ b/jazzy/release-ubuntu-arm64-build.yaml
@@ -3,9 +3,9 @@
 ---
 abi_incompatibility_assumed: true
 jenkins_binary_job_label: buildagent_arm64 || jazzy_binarydeb_unv8
-jenkins_binary_job_priority: 80
+jenkins_binary_job_priority: 83
 jenkins_binary_job_timeout: 150
-jenkins_source_job_priority: 70
+jenkins_source_job_priority: 73
 jenkins_source_job_timeout: 30
 notifications:
   emails:

--- a/jazzy/source-build.yaml
+++ b/jazzy/source-build.yaml
@@ -6,9 +6,9 @@ build_environment_variables:
   ROS_PYTHON_VERSION: 3
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon
-jenkins_commit_job_priority: 50
+jenkins_commit_job_priority: 53
 jenkins_job_timeout: 120
-jenkins_pull_request_job_priority: 40
+jenkins_pull_request_job_priority: 43
 notifications:
   committers: true
   compiler_warnings: true


### PR DESCRIPTION
It appears that when these configs were copied from Rolling, the job priority wasn't adjusted. This change follows the pattern employed by all the other distributions.

<details>

```
$ ./list_priorities.py 
40
  jenkins_pull_request_job_priority::rolling/source-build.yaml
43
  jenkins_pull_request_job_priority::jazzy/source-build.yaml
45
  jenkins_pull_request_job_priority::humble/source-build.yaml
50
  jenkins_commit_job_priority::rolling/source-build.yaml
  jenkins_job_priority::rolling/ci-benchmark.yaml
  jenkins_job_priority::rolling/ci-nightly-connext.yaml
  jenkins_job_priority::rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
  jenkins_job_priority::rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
  jenkins_job_priority::rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml
  jenkins_job_priority::rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
  jenkins_job_priority::rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
  jenkins_job_priority::rolling/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
  jenkins_job_priority::rolling/ci-nightly-cyclonedds.yaml
  jenkins_job_priority::rolling/ci-nightly-debug.yaml
  jenkins_job_priority::rolling/ci-nightly-extra-rmw-release.yaml
  jenkins_job_priority::rolling/ci-nightly-fastrtps-dynamic.yaml
  jenkins_job_priority::rolling/ci-nightly-fastrtps.yaml
  jenkins_job_priority::rolling/ci-nightly-performance.yaml
  jenkins_job_priority::rolling/ci-nightly-release.yaml
  jenkins_job_priority::rolling/ci-nightly-zenoh.yaml
  jenkins_job_priority::rolling/ci-overlay.yaml
53
  jenkins_commit_job_priority::jazzy/source-build.yaml
  jenkins_job_priority::jazzy/ci-benchmark.yaml
  jenkins_job_priority::jazzy/ci-nightly-connext.yaml
  jenkins_job_priority::jazzy/ci-nightly-cross-vendor-connext-cyclonedds.yaml
  jenkins_job_priority::jazzy/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
  jenkins_job_priority::jazzy/ci-nightly-cross-vendor-connext-fastrtps.yaml
  jenkins_job_priority::jazzy/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
  jenkins_job_priority::jazzy/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
  jenkins_job_priority::jazzy/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
  jenkins_job_priority::jazzy/ci-nightly-cyclonedds.yaml
  jenkins_job_priority::jazzy/ci-nightly-debug.yaml
  jenkins_job_priority::jazzy/ci-nightly-extra-rmw-release.yaml
  jenkins_job_priority::jazzy/ci-nightly-fastrtps-dynamic.yaml
  jenkins_job_priority::jazzy/ci-nightly-fastrtps.yaml
  jenkins_job_priority::jazzy/ci-nightly-performance.yaml
  jenkins_job_priority::jazzy/ci-nightly-release.yaml
  jenkins_job_priority::jazzy/ci-overlay.yaml
55
  jenkins_commit_job_priority::humble/source-build.yaml
  jenkins_job_priority::humble/ci-benchmark.yaml
  jenkins_job_priority::humble/ci-nightly-connext.yaml
  jenkins_job_priority::humble/ci-nightly-cross-vendor-connext-cyclonedds.yaml
  jenkins_job_priority::humble/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
  jenkins_job_priority::humble/ci-nightly-cross-vendor-connext-fastrtps.yaml
  jenkins_job_priority::humble/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
  jenkins_job_priority::humble/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
  jenkins_job_priority::humble/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
  jenkins_job_priority::humble/ci-nightly-cyclonedds.yaml
  jenkins_job_priority::humble/ci-nightly-debug.yaml
  jenkins_job_priority::humble/ci-nightly-extra-rmw-release.yaml
  jenkins_job_priority::humble/ci-nightly-fastrtps-dynamic.yaml
  jenkins_job_priority::humble/ci-nightly-fastrtps.yaml
  jenkins_job_priority::humble/ci-nightly-performance.yaml
  jenkins_job_priority::humble/ci-nightly-release.yaml
  jenkins_job_priority::humble/ci-overlay.yaml
70
  jenkins_source_job_priority::rolling/release-build.yaml
  jenkins_source_job_priority::rolling/release-rhel-build.yaml
  jenkins_source_job_priority::rolling/release-ubuntu-arm64-build.yaml
73
  jenkins_source_job_priority::jazzy/release-build.yaml
  jenkins_source_job_priority::jazzy/release-rhel-build.yaml
  jenkins_source_job_priority::jazzy/release-ubuntu-arm64-build.yaml
75
  jenkins_source_job_priority::humble/release-build.yaml
  jenkins_source_job_priority::humble/release-rhel-build.yaml
  jenkins_source_job_priority::humble/release-ubuntu-arm64-build.yaml
80
  jenkins_binary_job_priority::rolling/release-build.yaml
  jenkins_binary_job_priority::rolling/release-rhel-build.yaml
  jenkins_binary_job_priority::rolling/release-ubuntu-arm64-build.yaml
83
  jenkins_binary_job_priority::jazzy/release-build.yaml
  jenkins_binary_job_priority::jazzy/release-rhel-build.yaml
  jenkins_binary_job_priority::jazzy/release-ubuntu-arm64-build.yaml
85
  jenkins_binary_job_priority::humble/release-build.yaml
  jenkins_binary_job_priority::humble/release-rhel-build.yaml
  jenkins_binary_job_priority::humble/release-ubuntu-arm64-build.yaml
89
  jenkins_job_priority::humble/doc-build.yaml
  jenkins_job_priority::jazzy/doc-build.yaml
  jenkins_job_priority::rolling/doc-build.yaml
```

</details>