### PR TITLE
Increse timeout to 390 minutes Kci and Rci debug and release

### DIFF
--- a/kilted/ci-nightly-debug.yaml
+++ b/kilted/ci-nightly-debug.yaml
@@ -11,7 +11,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 jenkins_job_label: ci-agent
 jenkins_job_priority: 52
 jenkins_job_schedule: 15 23 3-30/3 * *
-jenkins_job_timeout: 360
+jenkins_job_timeout: 390
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:

--- a/kilted/ci-nightly-release.yaml
+++ b/kilted/ci-nightly-release.yaml
@@ -11,7 +11,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 jenkins_job_label: ci-agent
 jenkins_job_priority: 52
 jenkins_job_schedule: 15 23 3-30/3 * *
-jenkins_job_timeout: 360
+jenkins_job_timeout: 390
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:

--- a/rolling/ci-nightly-debug.yaml
+++ b/rolling/ci-nightly-debug.yaml
@@ -11,7 +11,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
-jenkins_job_timeout: 360
+jenkins_job_timeout: 390
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:

--- a/rolling/ci-nightly-release.yaml
+++ b/rolling/ci-nightly-release.yaml
@@ -11,7 +11,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
-jenkins_job_timeout: 360
+jenkins_job_timeout: 390
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:


### PR DESCRIPTION
## Description

These 4 jobs have been struggling to finish because most of them are timing out. The builds that finish are near the 360 minutes threshold, so some of them fail and some others finish.

This PR increases the timeout threshold slightly (30 minutes) to see if they actually pass this time.

See the current build trend of related jobs (May 29th, 2025):
- https://build.ros2.org/view/Rci/job/Rci__nightly-debug_ubuntu_noble_amd64/buildTimeTrend
- https://build.ros2.org/view/Rci/job/Rci__nightly-release_ubuntu_noble_amd64/buildTimeTrend
- https://build.ros2.org/view/Kci/job/Kci__nightly-debug_ubuntu_noble_amd64/buildTimeTrend
- https://build.ros2.org/view/Kci/job/Kci__nightly-release_ubuntu_noble_amd64/buildTimeTrend

A reason of these failures may come from the amount of test regressions that are happening on the buildfarm right now, as most of them need to be re-tested multiple times with the `--retest-until-pass 2` flag.
