### PR TITLE
Remove the rsl package from the Humble RHEL blacklist

### DIFF
--- a/humble/release-rhel-build.yaml
+++ b/humble/release-rhel-build.yaml
@@ -53,7 +53,6 @@ package_blacklist:
 - ros_gz_interfaces  # gazebo has no RPM packages for RHEL
 - ros_gz_sim  # gazebo has no RPM packages for RHEL
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
-- rsl  # Not yet generated for RHEL
 - sdformat_test_files  # sdformat has no RPM packages for RHEL 8
 - sdformat_urdf  # sdformat has no RPM packages for RHEL 8
 - swri_console_util  # Build failures on all platforms. https://github.com/swri-robotics/marti_common/issues/665


### PR DESCRIPTION
## Description

`rsl` for Humble on RHEL is now expected to build. I manually enabled the src and bin jobs last week are they passed: https://github.com/ros/rosdistro/pull/46443#issuecomment-2985719994.

Remove the package from the blacklist here so that it doesn't get re-disabled.

### Is this user-facing behavior change?

N/A

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
