### PR TITLE
Remove the rsl package from the Jazzy RHEL blacklist

### DIFF
--- a/jazzy/release-rhel-build.yaml
+++ b/jazzy/release-rhel-build.yaml
@@ -51,7 +51,6 @@ package_blacklist:
 - ros_ign_interfaces  # ignition has no RPM packages for RHEL
 - ros_industrial_cmake_boilerplate  # iwyu has no RPM packages for RHEL 9
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
-- rsl  # Requires CMake 3.22
 - sol_vendor  # Targets 'HEAD' in vendor package
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
 - tvm_vendor  # Build failures on AlmaLinux (but not RHEL)


### PR DESCRIPTION
## Description

Follow-up to #335

The package also builds for Jazzy on RHEL 9, since RHEL 9 uses CMake >=3.22 (and [not 3.20](https://www.ros.org/reps/rep-2000.html#jazzy-jalisco-may-2024-may-2029)) in practice:

* https://build.ros2.org/job/Jsrc_el9__rsl__rhel_9__source/1/
* https://build.ros2.org/job/Jbin_rhel_el964__rsl__rhel_9_x86_64__binary/1/

so remove it from the list.

### Is this user-facing behavior change?

N/A

### Did you use Generative AI?

No

### Additional Information
