### PR TITLE
remove spinnaker cam drivers from RHEL because SDK not available as RPM

### DIFF
--- a/kilted/release-rhel-build.yaml
+++ b/kilted/release-rhel-build.yaml
@@ -52,6 +52,8 @@ package_blacklist:
 - ros_industrial_cmake_boilerplate  # iwyu has no RPM packages for RHEL 9
 - ros1_bridge  # ROS Noetic has no RPM packages for RHEL
 - sol_vendor  # Targets 'HEAD' in vendor package
+- spinnaker_camera_driver # spinnaker SDK not available as RPM package
+- spinnaker_synchronized_camera_driver # depends on spinnaker_camera_driver
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
 - tvm_vendor  # Build failures on AlmaLinux (but not RHEL)
 - ur_dashboard_msgs  # Upstream for ur_robot_driver, for which docker.io has no RPM packages for RHEL


### PR DESCRIPTION
## Description

The FLIR Spinnaker SDK for the FLIR line of cameras is not provided in RPM format and hence the build fails. This PR should stop the annoying build failure emails I'm getting every day, and reduce pointless load on the build farm.

This PR follows @tfoote's suggestion [on ROS discourse](https://discourse.ros.org/t/how-to-disable-building-rosdistro-package-on-specific-os-platform/45204/2?u=bernd_pfrommer)

This PR does not fix an issue because no issue was opened related to this (I was not aware of this repo when I posed the question on ROS discourse).

### Is this user-facing behavior change?

No. The package was never built on RHEL. The PR will just stop annoying messages about build failures (and reduce build farm load)


### Did you use Generative AI?
Emphatically: no.


### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
