### PR TITLE
Use nightly-release as underlay for extra-rmw-release

### DIFF
--- a/rolling/ci-benchmark.yaml
+++ b/rolling/ci-benchmark.yaml
@@ -75,5 +75,6 @@ targets:
       amd64:
 type: ci-build
 underlay_from_ci_jobs:
+- nightly-release
 - nightly-extra-rmw-release
 version: 1

--- a/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -75,5 +75,6 @@ targets:
       amd64:
 type: ci-build
 underlay_from_ci_jobs:
+- nightly-release
 - nightly-extra-rmw-release
 version: 1

--- a/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -74,5 +74,6 @@ targets:
       amd64:
 type: ci-build
 underlay_from_ci_jobs:
+- nightly-release
 - nightly-extra-rmw-release
 version: 1

--- a/rolling/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -72,5 +72,6 @@ targets:
       amd64:
 type: ci-build
 underlay_from_ci_jobs:
+- nightly-release
 - nightly-extra-rmw-release
 version: 1

--- a/rolling/ci-nightly-extra-rmw-release.yaml
+++ b/rolling/ci-nightly-extra-rmw-release.yaml
@@ -8,6 +8,8 @@ build_environment_variables:
 build_tool: colcon
 build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS=1 --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
+install_packages:
+- libssl-dev  # for Fast-DDS security
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_timeout: 300

--- a/rolling/ci-nightly-extra-rmw-release.yaml
+++ b/rolling/ci-nightly-extra-rmw-release.yaml
@@ -10,9 +10,11 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
-jenkins_job_schedule: 15 23 * * *
 jenkins_job_timeout: 300
+jenkins_job_upstream_triggers:
+- nightly-release
 jenkins_job_weight: 4
+package_selection_args: '--packages-above rmw_fastrtps_dynamic_cpp'
 repos_files:
 - https://github.com/ros2/ros2/raw/rolling/ros2.repos
 repositories:
@@ -67,4 +69,6 @@ targets:
     noble:
       amd64:
 type: ci-build
+underlay_from_ci_jobs:
+- nightly-release
 version: 1

--- a/rolling/ci-nightly-performance.yaml
+++ b/rolling/ci-nightly-performance.yaml
@@ -74,6 +74,7 @@ targets:
       amd64:
 type: ci-build
 underlay_from_ci_jobs:
+- nightly-release
 - nightly-extra-rmw-release
 archive_files:
 - ws/test_results/buildfarm_perf_tests/performance_test_results_*.csv

--- a/rolling/ci-overlay.yaml
+++ b/rolling/ci-overlay.yaml
@@ -67,5 +67,6 @@ targets:
       amd64:
 type: ci-build
 underlay_from_ci_jobs:
+- nightly-release
 - nightly-extra-rmw-release
 version: 1


### PR DESCRIPTION
At present, the only difference between `nightly-release` and `extra-rmw-release` jobs is the latter's inclusion of `rmw_fastrtps_dynamic_cpp`. Rather than re-build and re-test EVERYTHING in `extra-rmw-release`, we should re-use the `nightly-release` and only re-build what we might need.

The result is that we'll re-use roughly half of the packages which are identical between these two jobs, and won't need to build or test them in this job for no reason. Because such a significant amount of this job's runtime is spent running cross-vendor tests I don't anticipate it will have a proportional impact on time savings, but it should be significant.

This change should be just as "safe" as the original approach because it re-builds everything that might be downstream of the additional packages. In the future, we may be able to scope this further to omit downstream packages which we know won't be affected by the additional RMW's presence.