### PR TITLE
Increase the timeout of extra-rmw-release jobs

### DIFF
--- a/kilted/ci-nightly-extra-rmw-release.yaml
+++ b/kilted/ci-nightly-extra-rmw-release.yaml
@@ -11,7 +11,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 jenkins_job_label: ci-agent
 jenkins_job_priority: 52
 jenkins_job_schedule: 15 23 3-30/3 * *
-jenkins_job_timeout: 300
+jenkins_job_timeout: 360
 jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/ros2/raw/kilted/ros2.repos

--- a/rolling/ci-nightly-extra-rmw-release.yaml
+++ b/rolling/ci-nightly-extra-rmw-release.yaml
@@ -11,7 +11,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
-jenkins_job_timeout: 300
+jenkins_job_timeout: 360
 jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/ros2/raw/rolling/ros2.repos


### PR DESCRIPTION
This job hasn't passed in Kci nor Rci in a while because build is timing out 

See: https://build.ros2.org/view/Kci/job/Kci__nightly-extra-rmw-release_ubuntu_noble_amd64/ and https://build.ros2.org/view/Kci/job/Rci__nightly-extra-rmw-release_ubuntu_noble_amd64/