### PR TITLE
Add Turtle Nest to RHEL blacklist

### DIFF
--- a/kilted/release-rhel-build.yaml
+++ b/kilted/release-rhel-build.yaml
@@ -97,6 +97,7 @@ package_blacklist:
 - spinnaker_camera_driver # spinnaker SDK not available as RPM package
 - spinnaker_synchronized_camera_driver # depends on spinnaker_camera_driver
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
+- turtle_nest # Turtle Nest does not support RHEL
 - tvm_vendor  # Build failures on AlmaLinux (but not RHEL)
 - ur_dashboard_msgs  # Upstream for ur_robot_driver, for which docker.io has no RPM packages for RHEL
 - usb_cam  # v4l-utils has no RPM package for RHEL

--- a/kilted/release-rhel-build.yaml
+++ b/kilted/release-rhel-build.yaml
@@ -97,7 +97,7 @@ package_blacklist:
 - spinnaker_camera_driver # spinnaker SDK not available as RPM package
 - spinnaker_synchronized_camera_driver # depends on spinnaker_camera_driver
 - tracetools_analysis  # jupyter-notebook has no RPM package for RHEL
-- turtle_nest # Turtle Nest does not support RHEL
+- turtle_nest  # python-black has no RPM package for RHEL
 - tvm_vendor  # Build failures on AlmaLinux (but not RHEL)
 - ur_dashboard_msgs  # Upstream for ur_robot_driver, for which docker.io has no RPM packages for RHEL
 - usb_cam  # v4l-utils has no RPM package for RHEL


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Adds Turtle Nest in the RHEL blacklist for Kilted. RHEL isn't supported, and I keep getting constant email spam only for the Kilted distro.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
No
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
