### PR TITLE
Blacklist Mapviz for RHEL

### DIFF
--- a/kilted/release-rhel-build.yaml
+++ b/kilted/release-rhel-build.yaml
@@ -30,6 +30,7 @@ package_blacklist:
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL
+- mapviz # Build failures on RHEL due to OpenGL dependency
 - nav2_amcl  # Nav2 will not support RHEL
 - nav2_behavior_tree  # Nav2 will not support RHEL
 - nav2_bringup  # Nav2 will not support RHEL


### PR DESCRIPTION
Blacklisting Mapviz because we do not really support RHEL, and there are build failures in Kilted on RHEL that we cannot reproduce locally.

## Description

Blacklists Mapviz for Kilted on RHEL.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

We have had ongoing build failures related to OpenGL dependencies on RHEL with Kilted. We cannot reproduce the failures locally, and they do not happen on other combinations of platforms and releases. We do not intentionally test for RHEL compatibility, so we would rather blacklist the package than devote resources to tracking down the root cause of this failure.

