### PR TITLE
disable 'open3d_vendor' (pre-compiled Open3D binaries) on arm64

### DIFF
--- a/jazzy/release-ubuntu-arm64-build.yaml
+++ b/jazzy/release-ubuntu-arm64-build.yaml
@@ -17,6 +17,7 @@ package_blacklist:
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
 - mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
+- open3d_vendor  # pre-compiled Open3D binaries not available for arm64
 package_dependency_behavior:
   include_test_dependencies: false
   run_package_tests: false

--- a/rolling/release-ubuntu-arm64-build.yaml
+++ b/rolling/release-ubuntu-arm64-build.yaml
@@ -21,6 +21,7 @@ package_blacklist:
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
 - mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
+- open3d_vendor  # pre-compiled Open3D binaries not available for arm64
 package_dependency_behavior:
   include_test_dependencies: false
   run_package_tests: false


### PR DESCRIPTION
## Description

The package `open3d_vendor` installs pre-compiled binaries, which are not available on `arm64`.

### Is this user-facing behavior change?

No. This package was not available for `arm64` before.

### Did you use Generative AI?

No.
