### PR TITLE
Add python3-sphinx-book-theme dependency for CI builds

### DIFF
--- a/global/ci-infra.yaml
+++ b/global/ci-infra.yaml
@@ -42,6 +42,7 @@ install_packages:
 - python3-pip
 - python3-scantree
 - python3-sphinx
+- python3-sphinx-book-theme
 - python3-sphinx-prompt
 - python3-sphinx-rtd-theme
 - python3-termcolor


### PR DESCRIPTION
## Description

This theme is used in the rosdoc2 tests.

### Is this user-facing behavior change?

Not really

### Did you use Generative AI?

No

### Additional Information

Cross-link to ros-infrastructure/rosdoc2#207