### PR TITLE
Increase timeout of Rolling performance

### DIFF
--- a/rolling/ci-nightly-performance.yaml
+++ b/rolling/ci-nightly-performance.yaml
@@ -15,7 +15,7 @@ install_packages:
 - libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
-jenkins_job_timeout: 180
+jenkins_job_timeout: 240
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
 jenkins_job_weight: 4


### PR DESCRIPTION
## Description

Fixes Rolling Performance Timeout

Rolling Performance job has been timing out for the last two builds:
- https://build.ros2.org/view/Rci/job/Rci__nightly-performance_ubuntu_noble_amd64/260/
- https://build.ros2.org/view/Rci/job/Rci__nightly-performance_ubuntu_noble_amd64/261/

It passed just in the threshold lower bound three days ago: https://build.ros2.org/view/Rci/job/Rci__nightly-performance_ubuntu_noble_amd64/259/. However, the builds before this build were 6 months ago, which suggest that there were a lot of changes to the code that caused the job to take more time.


This PR increases the timeout threshold for Rolling Performance so it can run.

CC: @miguelgonrod