### PR TITLE
Bump Kci performance and Rci connext timeout

### DIFF
--- a/kilted/ci-nightly-performance.yaml
+++ b/kilted/ci-nightly-performance.yaml
@@ -15,7 +15,7 @@ install_packages:
 - libtinyxml2-dev  # for Fast-DDS, which doesn't install its manifest
 jenkins_job_label: ci-agent
 jenkins_job_priority: 52
-jenkins_job_timeout: 180
+jenkins_job_timeout: 240
 jenkins_job_upstream_triggers:
 - nightly-extra-rmw-release
 jenkins_job_weight: 4

--- a/rolling/ci-nightly-connext.yaml
+++ b/rolling/ci-nightly-connext.yaml
@@ -11,7 +11,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
-jenkins_job_timeout: 300
+jenkins_job_timeout: 330
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore-regex .*cyclonedds.* rmw_fastrtps.* .*zenoh*.'
 repos_files:


### PR DESCRIPTION
## Description

- https://build.ros2.org/view/Kci/job/Kci__nightly-performance_ubuntu_noble_amd64/2/ takes the time to run that it really near to the timeout threshold, so we're bumping the timeout 60 minutes
- https://build.ros2.org/view/Rci/job/Rci__nightly-connext_ubuntu_noble_amd64/568/ sometimes times out, so we want to bump it just 30 minutes