### PR TITLE
Add Ubuntu Jammy to infrastructure CI job

### DIFF
--- a/global/ci-infra.yaml
+++ b/global/ci-infra.yaml
@@ -101,6 +101,8 @@ repositories:
   - http://repos.ros.org/repos/ros_bootstrap
 targets:
   ubuntu:
+    jammy:
+      amd64:
     noble:
       amd64:
 type: ci-build


### PR DESCRIPTION
## Description

This is a supported platform for supporting ROS and Gazebo, so we should enable regular tests of our packages there.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

Local tests show a single test failure in `rosdoc2`, which we should address once the job is running.