### PR TITLE
Clean up Zenoh environment variables in ci-nightly-zenoh

### DIFF
--- a/rolling/ci-nightly-zenoh.yaml
+++ b/rolling/ci-nightly-zenoh.yaml
@@ -3,9 +3,6 @@
 ---
 build_environment_variables:
   ROS_PYTHON_VERSION: '3'
-  RUST_LOG: 'z=error'
-  ZENOH_CONFIG_OVERRIDE: 'scouting/multicast/enabled=true'
-  ZENOH_ROUTER_CHECK_ATTEMPTS: '-1'
 build_tool: colcon
 build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'


### PR DESCRIPTION


## Description

Removed environment variables for Zenoh that are no longer needed now that we support isolated test fixtures.

The envar enables mutlicast scouting which is not needed with the test fixture that will automatically start the router. 

There is a suspicion that having both multicast and unicast discovery enabled simultaneously might be causing the flakiness observed in https://github.com/ros2/launch_ros/issues/503. 

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

Will follow up in a separate PR to remove these envars in the kilted job as well.