### PR TITLE
do not build metavision driver for rhel

### DIFF
--- a/kilted/release-rhel-build.yaml
+++ b/kilted/release-rhel-build.yaml
@@ -30,6 +30,7 @@ package_blacklist:
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL
+- metavision_driver # libosg not available for RHEL
 - nav2_amcl  # Nav2 will not support RHEL
 - nav2_behavior_tree  # Nav2 will not support RHEL
 - nav2_bringup  # Nav2 will not support RHEL


### PR DESCRIPTION
## Description

The metavision driver (for event-based cameras) requires the Open Scene Graph library (libosg),  which is not available under RHEL. This PR blacklists the metavision_driver to avoid repeated attempts to build the package.

### Is this user-facing behavior change?

Not sure what that means. I don't think anybody has been using the metavision driver on RHEL yet.

### Did you use Generative AI?

No.

### Additional Information

None.