### PR TITLE
Add Resolute as target for Rolling CI

### DIFF
--- a/rolling/ci-benchmark.yaml
+++ b/rolling/ci-benchmark.yaml
@@ -73,6 +73,8 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 underlay_from_ci_jobs:
 - nightly-extra-rmw-release

--- a/rolling/ci-nightly-connext.yaml
+++ b/rolling/ci-nightly-connext.yaml
@@ -67,5 +67,7 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 version: 1

--- a/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -73,6 +73,8 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 underlay_from_ci_jobs:
 - nightly-release

--- a/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -73,6 +73,8 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 underlay_from_ci_jobs:
 - nightly-extra-rmw-release

--- a/rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -71,6 +71,8 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 underlay_from_ci_jobs:
 - nightly-release

--- a/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -72,6 +72,8 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 underlay_from_ci_jobs:
 - nightly-extra-rmw-release

--- a/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/rolling/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -70,6 +70,8 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 underlay_from_ci_jobs:
 - nightly-release

--- a/rolling/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -70,6 +70,8 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 underlay_from_ci_jobs:
 - nightly-extra-rmw-release

--- a/rolling/ci-nightly-cyclonedds.yaml
+++ b/rolling/ci-nightly-cyclonedds.yaml
@@ -65,6 +65,8 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 upload_directory: nightly-cyclonedds
 version: 1

--- a/rolling/ci-nightly-debug.yaml
+++ b/rolling/ci-nightly-debug.yaml
@@ -68,5 +68,7 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 version: 1

--- a/rolling/ci-nightly-extra-rmw-release.yaml
+++ b/rolling/ci-nightly-extra-rmw-release.yaml
@@ -66,5 +66,7 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 version: 1

--- a/rolling/ci-nightly-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-fastrtps-dynamic.yaml
@@ -65,5 +65,7 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 version: 1

--- a/rolling/ci-nightly-fastrtps.yaml
+++ b/rolling/ci-nightly-fastrtps.yaml
@@ -65,5 +65,7 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 version: 1

--- a/rolling/ci-nightly-performance.yaml
+++ b/rolling/ci-nightly-performance.yaml
@@ -72,6 +72,8 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 underlay_from_ci_jobs:
 - nightly-extra-rmw-release

--- a/rolling/ci-nightly-release.yaml
+++ b/rolling/ci-nightly-release.yaml
@@ -67,5 +67,7 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 version: 1

--- a/rolling/ci-nightly-zenoh.yaml
+++ b/rolling/ci-nightly-zenoh.yaml
@@ -65,5 +65,7 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 version: 1

--- a/rolling/ci-overlay.yaml
+++ b/rolling/ci-overlay.yaml
@@ -65,6 +65,8 @@ targets:
   ubuntu:
     noble:
       amd64:
+    resolute:
+      amd64:
 type: ci-build
 underlay_from_ci_jobs:
 - nightly-extra-rmw-release


### PR DESCRIPTION
## Description

It's 2026 and with that comes the version bump of Ubuntu for ROS (26.04 - Resolute Racoon). To start ironing out the divergences it's necessary to start running CI on the new Ubuntu version. 

This PR adds Resolute as target for Rolling CI jobs on build.ros2.org. 

https://github.com/ros-infrastructure/ros_buildfarm/pull/1113 is needed before for `ros_buildfarm` scripts to work.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
No
### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No

