### PR TITLE
Disable gz_rendering_vendor release builds on RHEL

### DIFF
--- a/jazzy/release-rhel-build.yaml
+++ b/jazzy/release-rhel-build.yaml
@@ -20,7 +20,7 @@ package_blacklist:
 - four_wheel_steering_msgs  # Requires unreleased changes
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
-- gz_rendering_vendor # # libogre-dev has no RPM package for RHEL
+- gz_rendering_vendor  # libogre-dev has no RPM package for RHEL
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL

--- a/jazzy/release-rhel-build.yaml
+++ b/jazzy/release-rhel-build.yaml
@@ -20,6 +20,7 @@ package_blacklist:
 - four_wheel_steering_msgs  # Requires unreleased changes
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
+- gz_rendering_vendor # # libogre-dev has no RPM package for RHEL
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL

--- a/kilted/release-rhel-build.yaml
+++ b/kilted/release-rhel-build.yaml
@@ -27,6 +27,7 @@ package_blacklist:
 - four_wheel_steering_msgs  # Requires unreleased changes
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
+- gz_rendering_vendor # # libogre-dev has no RPM package for RHEL
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL

--- a/kilted/release-rhel-build.yaml
+++ b/kilted/release-rhel-build.yaml
@@ -27,7 +27,7 @@ package_blacklist:
 - four_wheel_steering_msgs  # Requires unreleased changes
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
-- gz_rendering_vendor # # libogre-dev has no RPM package for RHEL
+- gz_rendering_vendor  # libogre-dev has no RPM package for RHEL
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -20,7 +20,7 @@ package_blacklist:
 - four_wheel_steering_msgs  # Requires unreleased changes
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
-- gz_rendering_vendor # # libogre-dev has no RPM package for RHEL
+- gz_rendering_vendor  # libogre-dev has no RPM package for RHEL
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -20,6 +20,7 @@ package_blacklist:
 - four_wheel_steering_msgs  # Requires unreleased changes
 - fuse_constraints  # Requires unreleased changes
 - gazebo_dev  # Gazebo has no RPM package
+- gz_rendering_vendor # # libogre-dev has no RPM package for RHEL
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL


### PR DESCRIPTION
## Description

Build fails since libogre-dev is not available on RHEL. See 

- https://build.ros2.org/job/Jsrc_el9__gz_rendering_vendor__rhel_9__source/
- https://build.ros2.org/job/Ksrc_el9__gz_rendering_vendor__rhel_9__source/
- https://build.ros2.org/job/Rsrc_el9__gz_rendering_vendor__rhel_9__source/

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
