### PR TITLE
Changed the job timeout limit

### DIFF
--- a/rolling/ci-nightly-zenoh.yaml
+++ b/rolling/ci-nightly-zenoh.yaml
@@ -9,7 +9,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
-jenkins_job_timeout: 300
+jenkins_job_timeout: 390
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore foonathan_memory_vendor rosidl_dynamic_typesupport_fastrtps --packages-ignore-regex .*connext.* .*cyclonedds.* .*fastdds.* .*rmw_fastrtps.*'
 repos_files:


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
The builds in `Rci__nightly-zenoh_ubuntu_noble_amd64` are timing out 
First: https://build.ros2.org/job/Rci__nightly-zenoh_ubuntu_noble_amd64/335/
Last: https://build.ros2.org/job/Rci__nightly-zenoh_ubuntu_noble_amd64/355/
With each build in middle failing

changes
```diff
- jenkins_job_timeout: 300
+ jenkins_job_timeout: 390
```

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #359 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
CC: @Crola1702 