### PR TITLE
Blacklist lvr2 package from being build on Ubuntu 22 arm64

### DIFF
--- a/humble/release-ubuntu-arm64-build.yaml
+++ b/humble/release-ubuntu-arm64-build.yaml
@@ -20,6 +20,7 @@ package_blacklist:
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
 - mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
+- lvr2 # LVR2 depends on libembree-dev, which is not available on Ubuntu 22 ARM64. https://packages.ubuntu.com/jammy/libembree-dev
 repositories:
   keys:
   - |

--- a/humble/release-ubuntu-arm64-build.yaml
+++ b/humble/release-ubuntu-arm64-build.yaml
@@ -20,7 +20,7 @@ package_blacklist:
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
 - mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
-- lvr2 # LVR2 depends on libembree-dev, which is not available on Ubuntu 22 ARM64. https://packages.ubuntu.com/jammy/libembree-dev
+- lvr2  # LVR2 depends on libembree-dev, which is not available on Ubuntu 22 ARM64. https://packages.ubuntu.com/jammy/libembree-dev
 repositories:
   keys:
   - |


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
The LVR2 project depends on embree. It can handle embree3 and embree4 but neither is available for ARM64 on Ubuntu 22. This PR adds lvr2 to the `package_blacklist`.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
