### PR TITLE
Switch Rolling CI builds to Connext 7.7.0

### DIFF
--- a/rolling/ci-benchmark.yaml
+++ b/rolling/ci-benchmark.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.3.0'
+  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.7.0'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 benchmark_patterns:

--- a/rolling/ci-nightly-connext.yaml
+++ b/rolling/ci-nightly-connext.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.3.0'
+  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.7.0'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon

--- a/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.3.0'
+  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.7.0'
   # must override since the default has been removed from RMW_IMPLEMENTATIONS
   RMW_IMPLEMENTATION: 'rmw_connextdds'
   RMW_IMPLEMENTATIONS: 'rmw_connextdds:rmw_cyclonedds_cpp'

--- a/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.3.0'
+  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.7.0'
   # must override since the default has been removed from RMW_IMPLEMENTATIONS
   RMW_IMPLEMENTATION: 'rmw_connextdds'
   RMW_IMPLEMENTATIONS: 'rmw_connextdds:rmw_fastrtps_dynamic_cpp'

--- a/rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/rolling/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.3.0'
+  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.7.0'
   RMW_IMPLEMENTATIONS: 'rmw_connextdds:rmw_fastrtps_cpp'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'

--- a/rolling/ci-nightly-debug.yaml
+++ b/rolling/ci-nightly-debug.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.3.0'
+  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.7.0'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon

--- a/rolling/ci-nightly-extra-rmw-release.yaml
+++ b/rolling/ci-nightly-extra-rmw-release.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.3.0'
+  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.7.0'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon

--- a/rolling/ci-nightly-performance.yaml
+++ b/rolling/ci-nightly-performance.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.3.0'
+  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.7.0'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 benchmark_patterns:

--- a/rolling/ci-nightly-release.yaml
+++ b/rolling/ci-nightly-release.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.3.0'
+  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.7.0'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon

--- a/rolling/ci-overlay.yaml
+++ b/rolling/ci-overlay.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm ci-build file
 ---
 build_environment_variables:
-  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.3.0'
+  CONNEXTDDS_DIR: '/opt/rti.com/rti_connext_dds-7.7.0'
   ROS_PYTHON_VERSION: '3'
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon

--- a/rolling/source-build.yaml
+++ b/rolling/source-build.yaml
@@ -2,7 +2,7 @@
 # ROS buildfarm source-build file
 ---
 build_environment_variables:
-  CONNEXTDDS_DIR: /opt/rti.com/rti_connext_dds-7.3.0
+  CONNEXTDDS_DIR: /opt/rti.com/rti_connext_dds-7.7.0
   ROS_PYTHON_VERSION: 3
   RTI_NC_LICENSE_ACCEPTED: 'yes'
 build_tool: colcon


### PR DESCRIPTION
## Description

Switch Rolling CI to use Connext 7.7.0 instead of Connext 7.3.0.

### Is this user-facing behavior change?

Rolling builds in the CI are now going to be run using Connext 7.7.0.

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
