### PR TITLE
Blacklist camera_aravis2 packages for RHEL

### DIFF
--- a/kilted/release-rhel-build.yaml
+++ b/kilted/release-rhel-build.yaml
@@ -119,6 +119,8 @@ package_blacklist:
 - webots_ros2_ur_e_description  # Not yet generated for RHEL
 - wiimote  # cwiid has no RPM package for RHEL
 - zmqpp_vendor  # Targets 'HEAD' in vendor package
+- camera_aravis2 # camera_aravis2 does not support RHEL
+- camera_aravis2_msgs # camera_aravis2 does not support RHEL
 package_dependency_behavior:
   include_test_dependencies: false
   run_package_tests: false

--- a/kilted/release-rhel-build.yaml
+++ b/kilted/release-rhel-build.yaml
@@ -18,6 +18,8 @@ package_blacklist:
 - acado_vendor  # Requires unreleased changes
 - ament_black  # python3-uvloop and black have no RPM packages for RHEL
 - ament_download  # Build failures on RHEL https://github.com/samsung-ros/ament_download/pull/3
+- camera_aravis2  # aravis-dev has no RPM package for RHEL
+- camera_aravis2_msgs  # aravis-dev has no RPM package for RHEL
 - control_box_rst  # coinor-libipopt-dev has no RPM for RHEL 9
 - costmap_queue   # Nav2 will not support RHEL
 - dwb_core  # Nav2 will not support RHEL
@@ -119,8 +121,6 @@ package_blacklist:
 - webots_ros2_ur_e_description  # Not yet generated for RHEL
 - wiimote  # cwiid has no RPM package for RHEL
 - zmqpp_vendor  # Targets 'HEAD' in vendor package
-- camera_aravis2 # camera_aravis2 does not support RHEL
-- camera_aravis2_msgs # camera_aravis2 does not support RHEL
 package_dependency_behavior:
   include_test_dependencies: false
   run_package_tests: false


### PR DESCRIPTION
Remove camera_aravis2 and camera_aravis2_msgs from the package list due to lack of RHEL support.

## Description

Hi, I would like to blacklist my packages [camera_aravis2 and camera_aravis2_msgs](https://github.com/FraunhoferIOSB/camera_aravis2) from the RHEL build. We do not provide support for it, and some dependencies are not available in the Fedora index.

You can find more info about my problem [in this discourse post](https://discourse.openrobotics.org/t/exclude-platforms-when-releasing-a-package/53939).

Thanks in advance!
