### PR TITLE
Roll to RHEL 10 on Rolling

### DIFF
--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -73,9 +73,9 @@ package_blacklist:
 - wiimote  # cwiid has no RPM package for RHEL
 - zmqpp_vendor  # Targets 'HEAD' in vendor package
 package_dependency_behavior:
+  include_group_dependencies: true
   include_test_dependencies: false
   run_package_tests: false
-  include_group_dependencies: true
 package_ignore_list:
 - connext_cmake_module  # No RPM package for Connext
 - demo_nodes_cpp_native_gurumdds  # No RPM package for GurumDDS

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -75,6 +75,7 @@ package_blacklist:
 package_dependency_behavior:
   include_test_dependencies: false
   run_package_tests: false
+  include_group_dependencies: true
 package_ignore_list:
 - connext_cmake_module  # No RPM package for Connext
 - demo_nodes_cpp_native_gurumdds  # No RPM package for GurumDDS

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -146,7 +146,7 @@ repositories:
 target_repository: http://repo.ros2.org/rhel/building
 targets:
   rhel:
-    '9':
+    '10':
       x86_64:
 type: release-build
 upload_credential_id: jenkins-agent


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->
Moves rolling jobs on build.ros2.org to RHEL 10.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes, all jobs on build.ros2.org for rolling and RHEL will now target RHEL 10.
### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
