### PR TITLE
Bump doc_ros2doc job timeout from 30 to 40

### DIFF
--- a/global/doc-ros2-documentation.yaml
+++ b/global/doc-ros2-documentation.yaml
@@ -7,7 +7,7 @@ doc_repositories:
     url: https://github.com/ros2/ros2_documentation.git
     branch: rolling
 jenkins_job_priority: 80
-jenkins_job_timeout: 30
+jenkins_job_timeout: 40
 notifications:
   emails:
   - clalancette@openrobotics.org


### PR DESCRIPTION
## Description

The job has been timing out every few days over the last 3-4 weeks, probably because we added another distro/branch (Lyrical) to the docs build. Bump the timeout value.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
