### PR TITLE
Add Lyrical CI jobs

### DIFF
--- a/humble/ci-nightly-connext.yaml
+++ b/humble/ci-nightly-connext.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/3 * *
+jenkins_job_schedule: 15 23 3-31/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rosbag2_converter_default_plugins --packages-ignore-regex .*cyclonedds.* rmw_fastrtps.*'

--- a/humble/ci-nightly-cyclonedds.yaml
+++ b/humble/ci-nightly-cyclonedds.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/3 * *
+jenkins_job_schedule: 15 23 3-31/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*fastrtps.*'

--- a/humble/ci-nightly-debug.yaml
+++ b/humble/ci-nightly-debug.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/3 * *
+jenkins_job_schedule: 15 23 3-31/4 * *
 jenkins_job_timeout: 360
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/humble/ci-nightly-extra-rmw-release.yaml
+++ b/humble/ci-nightly-extra-rmw-release.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/3 * *
+jenkins_job_schedule: 15 23 3-31/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 repos_files:

--- a/humble/ci-nightly-fastrtps-dynamic.yaml
+++ b/humble/ci-nightly-fastrtps-dynamic.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/3 * *
+jenkins_job_schedule: 15 23 3-31/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp rosbag2_converter_default_plugins --packages-ignore-regex .*connext.* .*cyclonedds.*'

--- a/humble/ci-nightly-fastrtps.yaml
+++ b/humble/ci-nightly-fastrtps.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/3 * *
+jenkins_job_schedule: 15 23 3-31/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.*'

--- a/humble/ci-nightly-release.yaml
+++ b/humble/ci-nightly-release.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 55
-jenkins_job_schedule: 15 23 2-29/3 * *
+jenkins_job_schedule: 15 23 3-31/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/index.yaml
+++ b/index.yaml
@@ -96,6 +96,24 @@ distributions:
     source_builds:
       default: kilted/source-build.yaml
   lyrical:
+    ci_builds:
+      benchmark: lyrical/ci-benchmark.yaml
+      nightly-connext: lyrical/ci-nightly-connext.yaml
+      nightly-cross-vendor-connext-cyclonedds: lyrical/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+      nightly-cross-vendor-connext-fastrtps: lyrical/ci-nightly-cross-vendor-connext-fastrtps.yaml
+      nightly-cross-vendor-connext-fastrtps-dynamic: lyrical/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+      nightly-cross-vendor-cyclonedds-fastrtps: lyrical/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+      nightly-cross-vendor-cyclonedds-fastrtps-dynamic: lyrical/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+      nightly-cross-vendor-fastrtps-fastrtps-dynamic: lyrical/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+      nightly-cyclonedds: lyrical/ci-nightly-cyclonedds.yaml
+      nightly-debug: lyrical/ci-nightly-debug.yaml
+      nightly-extra-rmw-release: lyrical/ci-nightly-extra-rmw-release.yaml
+      nightly-fastrtps: lyrical/ci-nightly-fastrtps.yaml
+      nightly-fastrtps-dynamic: lyrical/ci-nightly-fastrtps-dynamic.yaml
+      nightly-performance: lyrical/ci-nightly-performance.yaml
+      nightly-release: lyrical/ci-nightly-release.yaml
+      nightly-zenoh: lyrical/ci-nightly-zenoh.yaml
+      overlay: lyrical/ci-overlay.yaml
     doc_builds:
       default: lyrical/doc-build.yaml
     notification_emails:

--- a/jazzy/ci-nightly-connext.yaml
+++ b/jazzy/ci-nightly-connext.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 53
-jenkins_job_schedule: 15 23 1-31/3 * *
+jenkins_job_schedule: 15 23 2-30/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore-regex .*cyclonedds.* rmw_fastrtps.*'

--- a/jazzy/ci-nightly-cyclonedds.yaml
+++ b/jazzy/ci-nightly-cyclonedds.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 53
-jenkins_job_schedule: 15 23 1-31/3 * *
+jenkins_job_schedule: 15 23 2-30/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor --packages-ignore-regex .*connext.* .*fastrtps.*'

--- a/jazzy/ci-nightly-debug.yaml
+++ b/jazzy/ci-nightly-debug.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 53
-jenkins_job_schedule: 15 23 1-31/3 * *
+jenkins_job_schedule: 15 23 2-30/4 * *
 jenkins_job_timeout: 360
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/jazzy/ci-nightly-extra-rmw-release.yaml
+++ b/jazzy/ci-nightly-extra-rmw-release.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 53
-jenkins_job_schedule: 15 23 1-31/3 * *
+jenkins_job_schedule: 15 23 2-30/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 repos_files:

--- a/jazzy/ci-nightly-fastrtps-dynamic.yaml
+++ b/jazzy/ci-nightly-fastrtps-dynamic.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 53
-jenkins_job_schedule: 15 23 1-31/3 * *
+jenkins_job_schedule: 15 23 2-30/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp --packages-ignore-regex .*connext.* .*cyclonedds.*'

--- a/jazzy/ci-nightly-fastrtps.yaml
+++ b/jazzy/ci-nightly-fastrtps.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 53
-jenkins_job_schedule: 15 23 1-31/3 * *
+jenkins_job_schedule: 15 23 2-30/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.*'

--- a/jazzy/ci-nightly-release.yaml
+++ b/jazzy/ci-nightly-release.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 53
-jenkins_job_schedule: 15 23 1-31/3 * *
+jenkins_job_schedule: 15 23 2-30/4 * *
 jenkins_job_timeout: 330
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/kilted/ci-nightly-connext.yaml
+++ b/kilted/ci-nightly-connext.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 52
-jenkins_job_schedule: 15 23 3-30/3 * *
+jenkins_job_schedule: 15 23 4-28/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore-regex .*cyclonedds.* rmw_fastrtps.* .*zenoh*.'

--- a/kilted/ci-nightly-cyclonedds.yaml
+++ b/kilted/ci-nightly-cyclonedds.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 52
-jenkins_job_schedule: 15 23 3-30/3 * *
+jenkins_job_schedule: 15 23 4-28/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor --packages-ignore-regex .*connext.* .*fastrtps.* .*fastdds.* .*zenoh.*'

--- a/kilted/ci-nightly-debug.yaml
+++ b/kilted/ci-nightly-debug.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 52
-jenkins_job_schedule: 15 23 3-30/3 * *
+jenkins_job_schedule: 15 23 4-28/4 * *
 jenkins_job_timeout: 390
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/kilted/ci-nightly-extra-rmw-release.yaml
+++ b/kilted/ci-nightly-extra-rmw-release.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 52
-jenkins_job_schedule: 15 23 3-30/3 * *
+jenkins_job_schedule: 15 23 4-28/4 * *
 jenkins_job_timeout: 360
 jenkins_job_weight: 4
 repos_files:

--- a/kilted/ci-nightly-fastrtps-dynamic.yaml
+++ b/kilted/ci-nightly-fastrtps-dynamic.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 52
-jenkins_job_schedule: 15 23 3-30/3 * *
+jenkins_job_schedule: 15 23 4-28/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp --packages-ignore-regex .*connext.* .*cyclonedds.* .*zenoh.*'

--- a/kilted/ci-nightly-fastrtps.yaml
+++ b/kilted/ci-nightly-fastrtps.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 52
-jenkins_job_schedule: 15 23 3-30/3 * *
+jenkins_job_schedule: 15 23 4-28/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.* .*zenoh.*'

--- a/kilted/ci-nightly-release.yaml
+++ b/kilted/ci-nightly-release.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 52
-jenkins_job_schedule: 15 23 3-30/3 * *
+jenkins_job_schedule: 15 23 4-28/4 * *
 jenkins_job_timeout: 390
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/kilted/ci-nightly-zenoh.yaml
+++ b/kilted/ci-nightly-zenoh.yaml
@@ -11,7 +11,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 52
-jenkins_job_schedule: 15 23 3-30/3 * *
+jenkins_job_schedule: 15 23 4-28/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore foonathan_memory_vendor rosidl_dynamic_typesupport_fastrtps --packages-ignore-regex .*connext.* .*cyclonedds.* .*fastdds.* .*rmw_fastrtps.*'

--- a/lyrical/ci-nightly-connext.yaml
+++ b/lyrical/ci-nightly-connext.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 51
-jenkins_job_schedule: 15 23 * * *
+jenkins_job_schedule: 15 23 1-29/4 * *
 jenkins_job_timeout: 330
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore-regex .*cyclonedds.* rmw_fastrtps.* .*zenoh*.'

--- a/lyrical/ci-nightly-cyclonedds.yaml
+++ b/lyrical/ci-nightly-cyclonedds.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 51
-jenkins_job_schedule: 15 23 * * *
+jenkins_job_schedule: 15 23 1-29/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor --packages-ignore-regex .*connext.* .*fastrtps.* .*fastdds.* .*zenoh.*'

--- a/lyrical/ci-nightly-debug.yaml
+++ b/lyrical/ci-nightly-debug.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Debug -DSKIP_MULTI_RMW_TESTS=1
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 51
-jenkins_job_schedule: 15 23 * * *
+jenkins_job_schedule: 15 23 1-29/4 * *
 jenkins_job_timeout: 390
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/lyrical/ci-nightly-extra-rmw-release.yaml
+++ b/lyrical/ci-nightly-extra-rmw-release.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 51
-jenkins_job_schedule: 15 23 * * *
+jenkins_job_schedule: 15 23 1-29/4 * *
 jenkins_job_timeout: 360
 jenkins_job_weight: 4
 repos_files:

--- a/lyrical/ci-nightly-fastrtps-dynamic.yaml
+++ b/lyrical/ci-nightly-fastrtps-dynamic.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 51
-jenkins_job_schedule: 15 23 * * *
+jenkins_job_schedule: 15 23 1-29/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp --packages-ignore-regex .*connext.* .*cyclonedds.* .*zenoh.*'

--- a/lyrical/ci-nightly-fastrtps.yaml
+++ b/lyrical/ci-nightly-fastrtps.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 51
-jenkins_job_schedule: 15 23 * * *
+jenkins_job_schedule: 15 23 1-29/4 * *
 jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.* .*zenoh.*'

--- a/lyrical/ci-nightly-release.yaml
+++ b/lyrical/ci-nightly-release.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release -DSKIP_MULTI_RMW_TESTS
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 51
-jenkins_job_schedule: 15 23 * * *
+jenkins_job_schedule: 15 23 1-29/4 * *
 jenkins_job_timeout: 390
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'

--- a/lyrical/ci-nightly-zenoh.yaml
+++ b/lyrical/ci-nightly-zenoh.yaml
@@ -8,7 +8,7 @@ build_tool_args: '--cmake-args --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 51
-jenkins_job_schedule: 15 23 * * *
+jenkins_job_schedule: 15 23 1-29/4 * *
 jenkins_job_timeout: 390
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore foonathan_memory_vendor rosidl_dynamic_typesupport_fastrtps --packages-ignore-regex .*connext.* .*cyclonedds.* .*fastdds.* .*rmw_fastrtps.*'


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes https://github.com/ros2/release-tracking/issues/59

Add Lyrical CI jobs to the buildfarm. Additionally, shift to using a four day instead of three day window for scheduling all jobs. 
The start date for each distribution is modified to add extra runs for newer LTS distros for the days at the end of the month that don't complete a four day cycle. The logic here is that newer distros tend to have more regressions than older distros. 
The non-LTS release (Kilted) is close to EOL so it's deprioritized. 
The schedule with this PR is:
 
| Distro | Cron | Pattern | Days of month |
|--------|------|---------|---------------|
| **Rolling** | `15 23 * * *` | Daily | Every day |
| **Lyrical** | `15 23 1-29/4 * *` | Every 4 days, starting day 1 | 1, 5, 9, 13, 17, 21, 25, 29 |
| **Jazzy** | `15 23 2-30/4 * *` | Every 4 days, starting day 2 | 2, 6, 10, 14, 18, 22, 26, 30 |
| **Humble** | `15 23 3-31/4 * *` | Every 4 days, starting day 3 | 3, 7, 11, 15, 19, 23, 27, 31 |
| **Kilted** | `15 23 4-28/4 * *` | Every 4 days, starting day 4 | 4, 8, 12, 16, 20, 24, 28 |


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes, CI will run on different days.
### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
