### PR TITLE
Increased lyrical overlay timeout

### DIFF
--- a/lyrical/ci-overlay.yaml
+++ b/lyrical/ci-overlay.yaml
@@ -10,7 +10,7 @@ build_tool_args: '--cmake-args -DCMAKE_BUILD_TYPE=Release --no-warn-unused-cli'
 build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-args -m "not xfail"'
 jenkins_job_label: ci-agent
 jenkins_job_priority: 51
-jenkins_job_timeout: 240
+jenkins_job_timeout: 600
 jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/ros2/raw/rolling/ros2.repos


### PR DESCRIPTION
## Description

With @Crola1702 we are testing why almost all lyrical and rolling jobs are failing by timeouts (Check ros2 dashboard) even when we increased the time limit. This is just for testing