### PR TITLE
Updated repos and mail to lyrical instead of rolling

### DIFF
--- a/lyrical/ci-benchmark.yaml
+++ b/lyrical/ci-benchmark.yaml
@@ -21,7 +21,7 @@ jenkins_job_upstream_triggers:
 jenkins_job_weight: 4
 package_selection_args: '--packages-above-depth 1 google_benchmark_vendor ament_cmake_google_benchmark performance_test_fixture'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-connext.yaml
+++ b/lyrical/ci-nightly-connext.yaml
@@ -15,7 +15,7 @@ jenkins_job_timeout: 360
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore-regex .*cyclonedds.* rmw_fastrtps.* .*zenoh*.'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-cross-vendor-connext-cyclonedds.yaml
+++ b/lyrical/ci-nightly-cross-vendor-connext-cyclonedds.yaml
@@ -21,7 +21,7 @@ jenkins_job_upstream_triggers:
 jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
+++ b/lyrical/ci-nightly-cross-vendor-connext-fastrtps-dynamic.yaml
@@ -21,7 +21,7 @@ jenkins_job_upstream_triggers:
 jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-cross-vendor-connext-fastrtps.yaml
+++ b/lyrical/ci-nightly-cross-vendor-connext-fastrtps.yaml
@@ -19,7 +19,7 @@ jenkins_job_upstream_triggers:
 jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
+++ b/lyrical/ci-nightly-cross-vendor-cyclonedds-fastrtps-dynamic.yaml
@@ -20,7 +20,7 @@ jenkins_job_upstream_triggers:
 jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
+++ b/lyrical/ci-nightly-cross-vendor-cyclonedds-fastrtps.yaml
@@ -18,7 +18,7 @@ jenkins_job_upstream_triggers:
 jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
+++ b/lyrical/ci-nightly-cross-vendor-fastrtps-fastrtps-dynamic.yaml
@@ -18,7 +18,7 @@ jenkins_job_upstream_triggers:
 jenkins_job_weight: 4
 package_selection_args: '--packages-select test_communication'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-cyclonedds.yaml
+++ b/lyrical/ci-nightly-cyclonedds.yaml
@@ -13,7 +13,7 @@ jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore fastcdr foonathan_memory_vendor --packages-ignore-regex .*connext.* .*fastrtps.* .*fastdds.* .*zenoh.*'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-debug.yaml
+++ b/lyrical/ci-nightly-debug.yaml
@@ -15,7 +15,7 @@ jenkins_job_timeout: 390
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-extra-rmw-release.yaml
+++ b/lyrical/ci-nightly-extra-rmw-release.yaml
@@ -14,7 +14,7 @@ jenkins_job_schedule: 15 23 1-29/4 * *
 jenkins_job_timeout: 390
 jenkins_job_weight: 4
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-fastrtps-dynamic.yaml
+++ b/lyrical/ci-nightly-fastrtps-dynamic.yaml
@@ -13,7 +13,7 @@ jenkins_job_timeout: 300
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_cpp --packages-ignore-regex .*connext.* .*cyclonedds.* .*zenoh.*'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-fastrtps.yaml
+++ b/lyrical/ci-nightly-fastrtps.yaml
@@ -13,7 +13,7 @@ jenkins_job_timeout: 360
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp --packages-ignore-regex .*connext.* .*cyclonedds.* .*zenoh.*'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-release.yaml
+++ b/lyrical/ci-nightly-release.yaml
@@ -15,7 +15,7 @@ jenkins_job_timeout: 390
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-nightly-zenoh.yaml
+++ b/lyrical/ci-nightly-zenoh.yaml
@@ -13,7 +13,7 @@ jenkins_job_timeout: 390
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore foonathan_memory_vendor rosidl_dynamic_typesupport_fastrtps --packages-ignore-regex .*connext.* .*cyclonedds.* .*fastdds.* .*rmw_fastrtps.*'
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/ci-overlay.yaml
+++ b/lyrical/ci-overlay.yaml
@@ -13,7 +13,7 @@ jenkins_job_priority: 51
 jenkins_job_timeout: 600
 jenkins_job_weight: 4
 repos_files:
-- https://github.com/ros2/ros2/raw/rolling/ros2.repos
+- https://github.com/ros2/ros2/raw/lyrical/ros2.repos
 repositories:
   keys:
   - |

--- a/lyrical/release-build.yaml
+++ b/lyrical/release-build.yaml
@@ -13,7 +13,7 @@ jenkins_source_job_timeout: 30
 notifications:
   emails:
   - steven+build.ros2.org@openrobotics.org
-  - ros2-buildfarm-rolling@googlegroups.com
+  - ros2-buildfarm-lyrical@googlegroups.com
   maintainers: true
 package_dependency_behavior:
   include_test_dependencies: false

--- a/lyrical/release-ubuntu-arm64-build.yaml
+++ b/lyrical/release-ubuntu-arm64-build.yaml
@@ -14,7 +14,7 @@ jenkins_source_job_timeout: 30
 notifications:
   emails:
   - steven+build.ros2.org@openrobotics.org
-  - ros2-buildfarm-rolling@googlegroups.com
+  - ros2-buildfarm-lyrical@googlegroups.com
   maintainers: true
 package_blacklist:
 - kortex_api  # Kinova does not provide arm64, only armv7. https://github.com/PickNikRobotics/ros2_kortex/issues/158

--- a/lyrical/source-build.yaml
+++ b/lyrical/source-build.yaml
@@ -14,7 +14,7 @@ notifications:
   compiler_warnings: true
   emails:
   - steven+build.ros2.org@openrobotics.org
-  - ros2-buildfarm-rolling@googlegroups.com
+  - ros2-buildfarm-lyrical@googlegroups.com
   maintainers: true
 repositories:
   keys:


### PR DESCRIPTION
## Description

After lyrical release, in the respective jobs it kept pointing to `rolling` repos and to `ros2-buildfarm-rolling@googlegroups.com` email. Changed repos and google groups to lyrical 

### Did you use Generative AI?
Nope