### PR TITLE
Increase lyrical debug timeout

### DIFF
--- a/lyrical/ci-nightly-debug.yaml
+++ b/lyrical/ci-nightly-debug.yaml
@@ -11,7 +11,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 jenkins_job_label: ci-agent
 jenkins_job_priority: 51
 jenkins_job_schedule: 15 23 1-29/4 * *
-jenkins_job_timeout: 390
+jenkins_job_timeout: 480
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:

--- a/lyrical/ci-nightly-extra-rmw-release.yaml
+++ b/lyrical/ci-nightly-extra-rmw-release.yaml
@@ -11,7 +11,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 jenkins_job_label: ci-agent
 jenkins_job_priority: 51
 jenkins_job_schedule: 15 23 1-29/4 * *
-jenkins_job_timeout: 390
+jenkins_job_timeout: 480
 jenkins_job_weight: 4
 repos_files:
 - https://github.com/ros2/ros2/raw/lyrical/ros2.repos

--- a/rolling/ci-nightly-release.yaml
+++ b/rolling/ci-nightly-release.yaml
@@ -11,7 +11,7 @@ build_tool_test_args: '--retest-until-pass 2 --ctest-args -LE xfail --pytest-arg
 jenkins_job_label: ci-agent
 jenkins_job_priority: 50
 jenkins_job_schedule: 15 23 * * *
-jenkins_job_timeout: 390
+jenkins_job_timeout: 480
 jenkins_job_weight: 4
 package_selection_args: '--packages-ignore rmw_fastrtps_dynamic_cpp'
 repos_files:


### PR DESCRIPTION
## Description

There keeps spawning jobs that are having timeouts :cry: 

- https://build.ros2.org/job/Lci__nightly-debug_ubuntu_resolute_amd64/10 

I checked that it failed by time and not because it freezed