### PR TITLE
Exclude librealsense2 / realsense2_camera packages from RHEL builds

### DIFF
--- a/humble/release-rhel-build.yaml
+++ b/humble/release-rhel-build.yaml
@@ -24,6 +24,7 @@ package_blacklist:
 - ign_rviz_common  # ignition has no RPM packages for RHEL
 - io_context  # asio has no RPM package for RHEL 8
 - libmavconn  # asio has no RPM package for RHEL 8
+- librealsense2  # librealsense SDK is not supported on RHEL / no RPM package
 - moveit_common  # libogre-dev has no RPM package for RHEL
 - moveit_resources_prbt_support  # libogre-dev has no RPM package for RHEL
 - mrpt2  # ffmpeg has no RPM package in supported repositories
@@ -38,6 +39,9 @@ package_blacklist:
 - ouster_msgs  # libtins-dev has no RPM package for RHEL
 - pepper_meshes  # Missing license agreement patches for packaging https://github.com/ros-naoqi/pepper_meshes2-release/issues/1
 - popf  # COIN-OR packages have no RPM packages for RHEL 8
+- realsense2_camera  # depends on librealsense2, which is not supported on RHEL
+- realsense2_camera_msgs  # part of realsense-ros; librealsense2 not supported on RHEL
+- realsense2_description  # part of realsense-ros; librealsense2 not supported on RHEL
 - rmf_building_map_tools  # ignition has no RPM packages for RHEL
 - rmf_building_sim_common  # ignition has no RPM packages for RHEL
 - rmf_demos_assets  # ignition has no RPM packages for RHEL

--- a/jazzy/release-rhel-build.yaml
+++ b/jazzy/release-rhel-build.yaml
@@ -25,6 +25,7 @@ package_blacklist:
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL
 - kobuki_core  # Build failures on RHEL due to -Werror
+- librealsense2  # librealsense SDK is not supported on RHEL / no RPM package
 - moveit_common  # libogre-dev has no RPM package for RHEL
 - moveit_resources_prbt_support  # libogre-dev has no RPM package for RHEL
 - mrpt2  # libfyaml has no RPM package for RHEL
@@ -37,6 +38,9 @@ package_blacklist:
 - performance_test  # Missing dependency on git: https://gitlab.com/ApexAI/performance_test/-/merge_requests/371
 - proxsuite  # simde and matio have no RPM packages for RHEL 9
 - py_trees_js  # python3-pyqt5.qtwebengine has no RPM packages for RHEL 9
+- realsense2_camera  # depends on librealsense2, which is not supported on RHEL
+- realsense2_camera_msgs  # part of realsense-ros; librealsense2 not supported on RHEL
+- realsense2_description  # part of realsense-ros; librealsense2 not supported on RHEL
 - rmf_building_map_tools  # ignition has no RPM packages for RHEL
 - rmf_building_sim_common  # ignition has no RPM packages for RHEL
 - rmf_demos_assets  # ignition has no RPM packages for RHEL

--- a/kilted/release-rhel-build.yaml
+++ b/kilted/release-rhel-build.yaml
@@ -33,6 +33,7 @@ package_blacklist:
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL
+- librealsense2  # librealsense SDK is not supported on RHEL / no RPM package
 - nav2_amcl  # Nav2 will not support RHEL
 - nav2_behavior_tree  # Nav2 will not support RHEL
 - nav2_bringup  # Nav2 will not support RHEL
@@ -80,6 +81,9 @@ package_blacklist:
 - openni2_camera  # libopenni2-dev does not exist on RHEL
 - proxsuite  # simde has no RPM package for RHEL 9
 - py_trees_js  # python3-pyqt5.qtwebengine has no RPM packages for RHEL 9
+- realsense2_camera  # depends on librealsense2, which is not supported on RHEL
+- realsense2_camera_msgs  # part of realsense-ros; librealsense2 not supported on RHEL
+- realsense2_description  # part of realsense-ros; librealsense2 not supported on RHEL
 - rmf_building_map_tools  # ignition has no RPM packages for RHEL
 - rmf_building_sim_common  # ignition has no RPM packages for RHEL
 - rmf_demos_assets  # ignition has no RPM packages for RHEL

--- a/lyrical/release-rhel-build.yaml
+++ b/lyrical/release-rhel-build.yaml
@@ -24,6 +24,7 @@ package_blacklist:
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL
+- librealsense2  # librealsense SDK is not supported on RHEL / no RPM package
 - moveit_common  # libogre-dev has no RPM package for RHEL
 - moveit_resources_prbt_support  # libogre-dev has no RPM package for RHEL
 - mrpt2  # libfyaml has no RPM package for RHEL
@@ -35,6 +36,9 @@ package_blacklist:
 - openni2_camera  # libopenni2-dev does not exist on RHEL
 - proxsuite  # simde has no RPM package for RHEL 9
 - py_trees_js  # python3-pyqt5.qtwebengine has no RPM packages for RHEL 9
+- realsense2_camera  # depends on librealsense2, which is not supported on RHEL
+- realsense2_camera_msgs  # part of realsense-ros; librealsense2 not supported on RHEL
+- realsense2_description  # part of realsense-ros; librealsense2 not supported on RHEL
 - rmf_building_map_tools  # ignition has no RPM packages for RHEL
 - rmf_building_sim_common  # ignition has no RPM packages for RHEL
 - rmf_demos_assets  # ignition has no RPM packages for RHEL

--- a/rolling/release-rhel-build.yaml
+++ b/rolling/release-rhel-build.yaml
@@ -24,6 +24,7 @@ package_blacklist:
 - ifm3d_core  # Build failures on RHEL https://github.com/ros2-gbp/ifm3d-release/issues/1
 - ign_ros2_control  # ignition has no RPM packages for RHEL
 - ign_rviz_common  # ignition has no RPM packages for RHEL
+- librealsense2  # librealsense SDK is not supported on RHEL / no RPM package
 - moveit_common  # libogre-dev has no RPM package for RHEL
 - moveit_resources_prbt_support  # libogre-dev has no RPM package for RHEL
 - mrpt2  # libfyaml has no RPM package for RHEL
@@ -35,6 +36,9 @@ package_blacklist:
 - openni2_camera  # libopenni2-dev does not exist on RHEL
 - proxsuite  # simde has no RPM package for RHEL 9
 - py_trees_js  # python3-pyqt5.qtwebengine has no RPM packages for RHEL 9
+- realsense2_camera  # depends on librealsense2, which is not supported on RHEL
+- realsense2_camera_msgs  # part of realsense-ros; librealsense2 not supported on RHEL
+- realsense2_description  # part of realsense-ros; librealsense2 not supported on RHEL
 - rmf_building_map_tools  # ignition has no RPM packages for RHEL
 - rmf_building_sim_common  # ignition has no RPM packages for RHEL
 - rmf_demos_assets  # ignition has no RPM packages for RHEL


### PR DESCRIPTION
**Overview:** The `librealsense2` SDK and the `realsense-ros` packages are not supported on RHEL — the RealSense SDK ships no RPM package and we do not support RHEL/RPM for this stack. Their RHEL binary jobs on build.ros2.org fail on every sync. This adds them to `package_blacklist` in each active distro's `release-rhel-build.yaml` so the build farm stops attempting (and failing) RHEL/RPM builds. Debian/Ubuntu builds are unaffected.

Packages excluded across `humble`, `jazzy`, `kilted`, `lyrical`, `rolling`:

- `librealsense2`
- `realsense2_camera`
- `realsense2_camera_msgs`
- `realsense2_description`

This follows the existing precedent for other vendor-SDK camera drivers that have no RHEL RPM (e.g. `spinnaker_camera_driver`).

I maintain these packages (realsense-ros / librealsense).

🤖 Generated by AI
