### PR TITLE
Re-enabling Mapviz on Arm

### DIFF
--- a/humble/release-ubuntu-arm64-build.yaml
+++ b/humble/release-ubuntu-arm64-build.yaml
@@ -19,7 +19,6 @@ package_blacklist:
 - kortex_api  # Kinova does not provide arm64, only armv7. https://github.com/PickNikRobotics/ros2_kortex/issues/158
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
-- mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
 - lvr2  # LVR2 depends on libembree-dev, which is not available on Ubuntu 22 ARM64. https://packages.ubuntu.com/jammy/libembree-dev
 repositories:
   keys:

--- a/jazzy/release-ubuntu-arm64-build.yaml
+++ b/jazzy/release-ubuntu-arm64-build.yaml
@@ -16,7 +16,6 @@ package_blacklist:
 - kortex_api  # Kinova does not provide arm64, only armv7. https://github.com/PickNikRobotics/ros2_kortex/issues/158
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
-- mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
 - open3d_vendor  # pre-compiled Open3D binaries not available for arm64
 package_dependency_behavior:
   include_test_dependencies: false

--- a/kilted/release-ubuntu-arm64-build.yaml
+++ b/kilted/release-ubuntu-arm64-build.yaml
@@ -19,7 +19,6 @@ package_blacklist:
 - kortex_api  # Kinova does not provide arm64, only armv7. https://github.com/PickNikRobotics/ros2_kortex/issues/158
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
-- mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
 package_dependency_behavior:
   include_test_dependencies: false
   run_package_tests: false

--- a/lyrical/release-ubuntu-arm64-build.yaml
+++ b/lyrical/release-ubuntu-arm64-build.yaml
@@ -20,7 +20,6 @@ package_blacklist:
 - kortex_api  # Kinova does not provide arm64, only armv7. https://github.com/PickNikRobotics/ros2_kortex/issues/158
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
-- mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
 - open3d_vendor  # pre-compiled Open3D binaries not available for arm64
 package_dependency_behavior:
   include_test_dependencies: false

--- a/rolling/release-ubuntu-arm64-build.yaml
+++ b/rolling/release-ubuntu-arm64-build.yaml
@@ -20,7 +20,6 @@ package_blacklist:
 - kortex_api  # Kinova does not provide arm64, only armv7. https://github.com/PickNikRobotics/ros2_kortex/issues/158
 - kortex_bringup  # depends on kortex_api and kortex_driver
 - kortex_driver  # depends on kortex_api and uses libKortexApiCpp.a from Kinova
-- mapviz  # Known issues with building on ARM processors. https://github.com/swri-robotics/mapviz/issues/777
 - open3d_vendor  # pre-compiled Open3D binaries not available for arm64
 package_dependency_behavior:
   include_test_dependencies: false


### PR DESCRIPTION
## Description

Re-enables building Mapviz on Arm platforms due to new Arm compatibility in recent Mapviz versions.

Fixes #392 

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No.

### Additional Information

None
