### PR TITLE
Enable automatic package sync to main for Rolling

### DIFF
--- a/rolling/release-build.yaml
+++ b/rolling/release-build.yaml
@@ -20,8 +20,8 @@ package_dependency_behavior:
   run_package_tests: false
 sync:
   auto_trigger_main: true
-  package_count: 499
-  packages: [desktop, desktop_full, simulation]
+  package_percent: 80
+  packages: [desktop_full]
 repositories:
   keys:
   - |

--- a/rolling/release-build.yaml
+++ b/rolling/release-build.yaml
@@ -19,6 +19,7 @@ package_dependency_behavior:
   include_test_dependencies: false
   run_package_tests: false
 sync:
+  auto_trigger_main: true
   package_count: 499
   packages: [desktop]
 repositories:

--- a/rolling/release-build.yaml
+++ b/rolling/release-build.yaml
@@ -21,7 +21,7 @@ package_dependency_behavior:
 sync:
   auto_trigger_main: true
   package_count: 499
-  packages: [desktop]
+  packages: [desktop, desktop_full, simulation]
 repositories:
   keys:
   - |


### PR DESCRIPTION
## Description

Enable automatic triggering of the sync-to-main job for Rolling after a successful sync-to-testing, gated on the availability of key packages across all architectures.

This uses the new `sync.auto_trigger_main` option introduced in https://github.com/ros-infrastructure/ros_buildfarm/pull/1151.

The `sync.packages` list has been updated to include `desktop-full` and `simulation` in addition to the existing `desktop` entry. This may be redundant since `simulation` includes the others but I felt this way we can simply drop `simulation` when we want to. 

Also considering adding packages that fall under the OSRF management like RMF, ros2_controls etc. Would like to discuss this with the PMC in the upcoming meeting.


Fixes # (issue)

NA

### Is this user-facing behavior change?

Yes. The Rolling `sync-to-main job` will now be triggered automatically after
each arch's sync-to-testing job succeeds, rather than requiring manual
triggering. The sync only proceeds if the existing criteria are met

### Did you use Generative AI?

No.

### Additional Information

The `auto_trigger_main` flag defaults to `false` in the buildfarm code, so
this change has no effect on other distributions.
