### PR TITLE
Update blocked packages for Lyrical on Fedora

### DIFF
--- a/lyrical/release-fedora-build.yaml
+++ b/lyrical/release-fedora-build.yaml
@@ -40,7 +40,6 @@ package_blacklist:
 - fuse_graphs  # build fails to find glog (ceres bug?)
 - fuse_loss  # build fails to find glog (ceres bug?)
 - fuse_variables  # build fails to find glog (ceres bug?)
-- generate_parameter_library  # references non-existant package 'tl_expected'
 - geodesy  # build fails due to ament_target_dependencies
 - hri  # build fails to find magic_enum.hpp
 - ifm3d_core  # build fails when trying to use /usr/src/gtest


### PR DESCRIPTION
This package was failing to build when I generated this list, but it's now working again.